### PR TITLE
 fix: 静默时段不影响自己农场 & Smart施肥范围过滤 & 日常自动放虫放草

### DIFF
--- a/core/src/core/worker.ts
+++ b/core/src/core/worker.ts
@@ -256,34 +256,28 @@ async function runHelpTick(auto: any): Promise<void> {
     if (helpTaskRunning) {
         return;
     }
-    if (!auto.friend_help) {
-        return;
-    }
-    // 检查是否开启了经验满不帮忙，且经验已达上限
-    const stopWhenExpLimit = !!auto.friend_help_exp_limit;
-    if (stopWhenExpLimit && isHelpExpLimitReached()) {
-        // 计算下次调度时间，但不执行巡查
-        const helpMs = randomIntervalMs(
-            workerConfig.helpCheckIntervalMin || 10000,
-            workerConfig.helpCheckIntervalMax || 10000
-        );
-        nextHelpRunAt = Date.now() + helpMs;
-        return;
-    }
     helpTaskRunning = true;
     const helpMs = randomIntervalMs(
         workerConfig.helpCheckIntervalMin || 10000,
         workerConfig.helpCheckIntervalMax || 10000
     );
-    //log('系统', `帮助巡查开始执行，下次间隔 ${helpMs}ms`, { module: 'system', event: '帮助巡查', result: 'start', intervalMs: helpMs });
     try {
-        await checkFriends({ onlyHelp: true });
+        // 帮助巡查
+        if (auto.friend_help) {
+            const stopWhenExpLimit = !!auto.friend_help_exp_limit;
+            if (!stopWhenExpLimit || !isHelpExpLimitReached()) {
+                await checkFriends({ onlyHelp: true });
+            }
+        }
+        // 捣乱独立于帮助执行，不受 friend_help 开关和经验上限影响
+        if (auto.friend_bad) {
+            await checkFriends({ onlyBad: true });
+        }
     } catch (e: any) {
-        log('系统', `帮助巡查执行失败: ${e.message}`, { module: 'system', event: '帮助巡查', result: 'error' });
+        log('系统', `巡查执行失败: ${e.message}`, { module: 'system', event: '巡查', result: 'error' });
     } finally {
         nextHelpRunAt = Date.now() + helpMs;
         helpTaskRunning = false;
-       // log('系统', `帮助巡查执行完成，下次执行时间: ${new Date(nextHelpRunAt).toISOString()}`, { module: 'system', event: '帮助巡查', result: 'done', nextRunAt: nextHelpRunAt });
     }
 }
 

--- a/core/src/services/farm/planting.ts
+++ b/core/src/services/farm/planting.ts
@@ -981,6 +981,10 @@ async function runFertilizerByConfig(plantedLands: any[] = [], options: { skipNo
             logWarn('施肥', `获取全农场地块失败 ${e.message}`);
         }
 
+        if (landTypeById.size > 0) {
+            organicTargets = filterLandIdsByTypes(organicTargets, landTypeById, selectedLandTypes);
+        }
+
         if (organicTargets.length > 0) {
             fertilizedOrganic = await fertilizeOrganicLoop(organicTargets);
             if (fertilizedOrganic > 0) {

--- a/core/src/services/farm/scheduler.ts
+++ b/core/src/services/farm/scheduler.ts
@@ -13,10 +13,6 @@ const { getAllLands, harvest, farming, unlockLand, upgradeLand } = require('./ap
 const { analyzeLands, resolveRemovableHarvestedLands } = require('./land-analysis');
 const { autoPlantEmptyLands, runFertilizerByConfig } = require('./planting');
 const { checkAndBuyFertilizerBoth } = require('../mall');
-// 延迟加载以打破循环依赖: visit-strategy → farm/index → scheduler → visit-strategy
-function inFriendQuietHours() {
-    return require('../friend/visit-strategy').inFriendQuietHours();
-}
 
 // ============ 内部状态 ============
 let isCheckingFarm: boolean = false;
@@ -33,7 +29,6 @@ let lastPushTime: number = 0;
 async function checkFarm(): Promise<boolean> {
     const state = getUserState();
     if (isCheckingFarm || !state.gid || !isAutomationOn('farm')) return false;
-    if (inFriendQuietHours()) return false;
     isCheckingFarm = true;
 
     try {


### PR DESCRIPTION
Fixes #22

### 修改 1：静默时段不对自己农场生效

`core/src/services/farm/scheduler.ts`

- 删除了 `checkFarm()` 中的 `if (inFriendQuietHours()) return false;` 检查
- 静默时段（friendQuietHours）现在只影响好友巡查，不再阻止自己农场的收获、种植、除草除虫等操作

### 修改 2：Smart 施肥模式有机肥按土地类型过滤

`core/src/services/farm/planting.ts`

- `smart` 模式（普通肥+快成熟有机肥）的有机肥路径缺少土地类型过滤，导致所有类型土地都会被施有机肥
- 修复后 `smart` 模式的有机肥也会先经过 `filterLandIdsByTypes` 过滤，只对勾选的土地类型施肥

### 修改 3：日常巡查自动执行放虫放草

`core/src/core/worker.ts`

- 修复外部调度器模式下捣乱（放虫放草）不执行的问题：外部调度器原本只有帮助和偷菜巡查，放虫放草只在启动时执行一次
- `runHelpTick` 中拆分为独立的两段：先执行捣乱（`checkFriends({ onlyBad: true })`），再执行帮助（`checkFriends({ onlyHelp: true })`）