### PR TITLE
fix: 按配置时区统一跨日重置，并修复好友 GID 持久化与好友农场未退出

### DIFF
--- a/core/src/config/config.ts
+++ b/core/src/config/config.ts
@@ -21,6 +21,7 @@ interface SystemConfig {
     clientVersion: string;
     platform: string;
     os: string;
+    timeZone: string;
     deviceInfo: DeviceInfo;
 }
 
@@ -40,6 +41,27 @@ interface RuntimeConfig extends SystemConfig {
 
 // clientVersion 由 CONFIG.clientVersion 动态获取，不写死在预设中
 const DEFAULT_CLIENT_VERSION = '1.13.2.8_20260723';
+const DEFAULT_TIME_ZONE = 'Asia/Shanghai';
+
+const TIME_ZONE_OPTIONS = [
+    { value: 'Asia/Shanghai', label: '北京时间 / 上海（UTC+8）' },
+    { value: 'UTC', label: '协调世界时（UTC）' },
+    { value: 'Asia/Hong_Kong', label: '香港' },
+    { value: 'Asia/Taipei', label: '台北' },
+    { value: 'Asia/Singapore', label: '新加坡' },
+    { value: 'Asia/Tokyo', label: '东京' },
+    { value: 'Asia/Seoul', label: '首尔' },
+    { value: 'Europe/London', label: '伦敦' },
+    { value: 'America/New_York', label: '纽约' },
+    { value: 'America/Los_Angeles', label: '洛杉矶' },
+] as const;
+
+const ALLOWED_TIME_ZONES: Set<string> = new Set(TIME_ZONE_OPTIONS.map(option => option.value));
+
+function normalizeTimeZone(input: unknown): string {
+    const value = String(input || '').trim();
+    return ALLOWED_TIME_ZONES.has(value) ? value : DEFAULT_TIME_ZONE;
+}
 
 const DEVICE_PRESETS: DevicePreset[] = [
     {
@@ -135,6 +157,7 @@ const DEFAULT_SYSTEM_CONFIG: SystemConfig = {
     clientVersion: DEFAULT_CLIENT_VERSION,
     platform: 'qq',
     os: DEFAULT_DEVICE_INFO.os,
+    timeZone: DEFAULT_TIME_ZONE,
     deviceInfo: { ...DEFAULT_DEVICE_INFO },
 };
 
@@ -143,6 +166,7 @@ const CONFIG: RuntimeConfig = {
     clientVersion: DEFAULT_CLIENT_VERSION,
     platform: DEFAULT_SYSTEM_CONFIG.platform,
     os: DEFAULT_SYSTEM_CONFIG.os,
+    timeZone: DEFAULT_SYSTEM_CONFIG.timeZone,
     deviceInfo: { ...DEFAULT_DEVICE_INFO },
     heartbeatInterval: 25000,
     farmCheckInterval: 3000,
@@ -181,6 +205,9 @@ function updateRuntimeConfig(newConfig: Partial<SystemConfig>): void {
     if (newConfig.os && typeof newConfig.os === 'string') {
         CONFIG.os = newConfig.os;
     }
+    if (newConfig.timeZone !== undefined) {
+        CONFIG.timeZone = normalizeTimeZone(newConfig.timeZone);
+    }
     if (newConfig.deviceInfo) {
         CONFIG.deviceInfo = normalizeDeviceInfo(newConfig.deviceInfo);
         // 同步 os 与 clientVersion 到顶层
@@ -195,6 +222,7 @@ function getRuntimeConfig(): SystemConfig {
         clientVersion: CONFIG.clientVersion,
         platform: CONFIG.platform,
         os: CONFIG.os,
+        timeZone: CONFIG.timeZone,
         deviceInfo: { ...CONFIG.deviceInfo },
     };
 }
@@ -208,6 +236,10 @@ function getDevicePresets(): DevicePreset[] {
         ...p,
         deviceInfo: { ...p.deviceInfo, clientVersion: CONFIG.clientVersion },
     }));
+}
+
+function getTimeZoneOptions(): Array<{ value: string; label: string }> {
+    return TIME_ZONE_OPTIONS.map(option => ({ ...option }));
 }
 
 // 生长阶段枚举
@@ -227,11 +259,14 @@ const PHASE_NAMES: string[] = ['未知', '种子', '发芽', '小叶', '大叶',
 module.exports = {
     CONFIG,
     DEFAULT_CLIENT_VERSION,
+    DEFAULT_TIME_ZONE,
     PlantPhase,
     PHASE_NAMES,
     updateRuntimeConfig,
     getRuntimeConfig,
     getDefaultSystemConfig,
     getDevicePresets,
+    getTimeZoneOptions,
+    normalizeTimeZone,
     DEVICE_PRESETS,
 };

--- a/core/src/controllers/admin/account-routes.ts
+++ b/core/src/controllers/admin/account-routes.ts
@@ -9,7 +9,7 @@ export {};
 const store = require('../../models/store');
 const { addOrUpdateAccount, deleteAccount } = store;
 const { findAccountByRef } = require('../../services/account-resolver');
-const { updateRuntimeConfig, getRuntimeConfig, getDefaultSystemConfig, getDevicePresets } = require('../../config/config');
+const { updateRuntimeConfig, getRuntimeConfig, getDefaultSystemConfig, getDevicePresets, getTimeZoneOptions } = require('../../config/config');
 
 const {
     getAccId,
@@ -390,6 +390,7 @@ function mountAccountRoutes(app: Application, ctx: AdminContext): void {
                     saved: store.getSystemConfig(),
                     default: getDefaultSystemConfig(),
                     current: getRuntimeConfig(),
+                    timeZones: getTimeZoneOptions(),
                 },
             });
         } catch (e: any) {
@@ -399,9 +400,12 @@ function mountAccountRoutes(app: Application, ctx: AdminContext): void {
 
     app.post('/api/settings/system-config', (req: Request, res: Response) => {
         try {
-            const { serverUrl, clientVersion, platform, os, deviceInfo } = req.body || {};
-            const saved = store.setSystemConfig({ serverUrl, clientVersion, platform, os, deviceInfo });
+            const { serverUrl, clientVersion, platform, os, timeZone, deviceInfo } = req.body || {};
+            const saved = store.setSystemConfig({ serverUrl, clientVersion, platform, os, timeZone, deviceInfo });
             updateRuntimeConfig(saved);
+            if (ctx.provider && typeof ctx.provider.broadcastConfig === 'function') {
+                ctx.provider.broadcastConfig('');
+            }
             res.json({ ok: true, data: { saved, current: getRuntimeConfig() } });
         } catch (e: any) {
             res.status(500).json({ ok: false, error: e.message });
@@ -413,6 +417,9 @@ function mountAccountRoutes(app: Application, ctx: AdminContext): void {
             const saved = getDefaultSystemConfig();
             store.setSystemConfig(saved);
             updateRuntimeConfig(saved);
+            if (ctx.provider && typeof ctx.provider.broadcastConfig === 'function') {
+                ctx.provider.broadcastConfig('');
+            }
             res.json({ ok: true, data: { saved, current: getRuntimeConfig() } });
         } catch (e: any) {
             res.status(500).json({ ok: false, error: e.message });

--- a/core/src/core/worker.ts
+++ b/core/src/core/worker.ts
@@ -4,7 +4,7 @@ export {};
  */
 const { parentPort, workerData } = require('node:worker_threads');
 
-const { CONFIG } = require('../config/config');
+const { CONFIG, updateRuntimeConfig } = require('../config/config');
 const { getLevelExpProgress, loadConfigs } = require('../config/gameConfig');
 const { getAutomation, getPreferredSeed, getConfigSnapshot, applyConfigSnapshot } = require('../models/store');
 const { checkAndClaimEmails } = require('../services/email');
@@ -26,7 +26,7 @@ const { cleanupTaskSystem, checkAndClaimTasks, getTaskClaimDailyState, getTaskDa
 const { sellAllFruits, getBag, getBagItems, openFertilizerGiftPacksSilently } = require('../services/warehouse');
 const { connect, cleanup, getWs, getUserState, networkEvents } = require('../utils/network');
 const { loadProto } = require('../utils/proto');
-const { setLogHook, log, logWarn, toNum } = require('../utils/utils');
+const { setLogHook, log, logWarn, toNum, getSystemDateKey, formatSystemDateTime24 } = require('../utils/utils');
 
 // Extend CONFIG with help/steal interval properties used by this worker
 interface WorkerRuntimeConfig {
@@ -72,27 +72,12 @@ function exitWorker(code: number = 0): void {
     process.exit(code);
 }
 
-function pad2(n: number): string {
-    return String(n).padStart(2, '0');
-}
-
-function formatLocalDateTime24(date: Date = new Date()): string {
-    const d = date instanceof Date ? date : new Date();
-    const y = d.getFullYear();
-    const m = pad2(d.getMonth() + 1);
-    const day = pad2(d.getDate());
-    const hh = pad2(d.getHours());
-    const mm = pad2(d.getMinutes());
-    const ss = pad2(d.getSeconds());
-    return `${y}-${m}-${day} ${hh}:${mm}:${ss}`;
-}
-
 // 捕获日志发送给主进程
 setLogHook((tag: string, msg: string, isWarn: boolean, meta: any) => {
     sendToMaster({
         type: 'log',
         data: {
-            time: formatLocalDateTime24(new Date()),
+            time: formatSystemDateTime24(),
             tag,
             msg,
             isWarn,
@@ -134,14 +119,6 @@ let runtimeGeneration: number = 0;
 let lastDailyRunDate: string = '';
 const workerScheduler = createScheduler('worker');
 
-function getLocalDateKey(): string {
-    const now = new Date();
-    const y = now.getFullYear();
-    const m = String(now.getMonth() + 1).padStart(2, '0');
-    const d = String(now.getDate()).padStart(2, '0');
-    return `${y}-${m}-${d}`;
-}
-
 async function runDailyRoutines(force: boolean = false): Promise<void> {
     if (!loginReady) return;
     try {
@@ -161,12 +138,12 @@ function stopDailyRoutineTimer(): void {
 
 function startDailyRoutineTimer(): void {
     stopDailyRoutineTimer();
-    lastDailyRunDate = getLocalDateKey();
+    lastDailyRunDate = getSystemDateKey();
     // 新账号登录后强制执行一次领取
     runDailyRoutines(true).catch(() => null);
     workerScheduler.setIntervalTask('daily_routine_interval', 30 * 1000, () => {
         if (!loginReady) return;
-        const today = getLocalDateKey();
+        const today = getSystemDateKey();
         if (today === lastDailyRunDate) return;
         lastDailyRunDate = today;
         runDailyRoutines(true).catch(() => null);
@@ -365,6 +342,9 @@ function applyRuntimeConfig(snapshot: any, syncNow: boolean = false): number {
 
     const prevAuto = getAutomation();
     const accountId = process.env.FARM_ACCOUNT_ID || '';
+    if (snapshot && snapshot.systemTimeZone !== undefined) {
+        updateRuntimeConfig({ timeZone: snapshot.systemTimeZone });
+    }
     applyConfigSnapshot(snapshot || {}, { persist: false, accountId });
     if (rev > appliedConfigRevision) appliedConfigRevision = rev;
 
@@ -442,8 +422,9 @@ async function startBot(config: any): Promise<void> {
     shutdownStarted = false;
     runtimeGeneration += 1;
 
-    const { code, platform } = config;
+    const { code, platform, systemTimeZone } = config;
 
+    if (systemTimeZone !== undefined) updateRuntimeConfig({ timeZone: systemTimeZone });
     CONFIG.platform = platform || 'qq';
     // 注意：间隔配置由 applyIntervalsToRuntime 统一处理，不要在这里覆盖
 
@@ -852,7 +833,7 @@ async function getDailyGiftOverview(): Promise<any> {
     const month = getMonthCardDailyState ? getMonthCardDailyState() : { doneToday: false, lastClaimAt: 0 };
 
     return {
-        date: new Date().toISOString().slice(0, 10),
+        date: getSystemDateKey(),
         growth: {
             key: 'growth_task',
             label: '成长任务',

--- a/core/src/models/store/global-config.ts
+++ b/core/src/models/store/global-config.ts
@@ -3,7 +3,7 @@ export {};
 
 const fs = require('node:fs');
 const { readTextFile, writeJsonFileAtomic } = require('../../services/json-db');
-const { DEFAULT_CLIENT_VERSION } = require('../../config/config');
+const { DEFAULT_CLIENT_VERSION, DEFAULT_TIME_ZONE, normalizeTimeZone } = require('../../config/config');
 
 const sharedState = require('./shared-state');
 
@@ -152,6 +152,7 @@ function setSystemConfig(config: Partial<SystemConfig> | undefined): SystemConfi
         clientVersion: deviceInfo.clientVersion,
         platform: String(config.platform || 'qq').trim(),
         os: deviceInfo.os,
+        timeZone: normalizeTimeZone(config.timeZone || DEFAULT_TIME_ZONE),
         deviceInfo,
     };
     saveGlobalConfig();

--- a/core/src/models/store/shared-state.ts
+++ b/core/src/models/store/shared-state.ts
@@ -3,7 +3,7 @@ export {};
 
 const fs = require('node:fs');
 const path = require('node:path');
-const { DEFAULT_CLIENT_VERSION } = require('../../config/config');
+const { DEFAULT_CLIENT_VERSION, DEFAULT_TIME_ZONE, normalizeTimeZone } = require('../../config/config');
 const { getDataFile, ensureDataDir } = require('../../config/runtime-paths');
 const { readTextFile, readJsonFile, writeJsonFileAtomic } = require('../../services/json-db');
 
@@ -434,6 +434,7 @@ function loadGlobalConfig(): void {
                     clientVersion: deviceClientVersion,
                     platform: String(data.systemConfig.platform || 'qq').trim(),
                     os: deviceOs,
+                    timeZone: normalizeTimeZone(data.systemConfig.timeZone || DEFAULT_TIME_ZONE),
                     deviceInfo: {
                         os: deviceOs,
                         clientVersion: deviceClientVersion,
@@ -445,7 +446,8 @@ function loadGlobalConfig(): void {
                     },
                 };
                 systemConfigMigrated = savedTopVersion !== deviceClientVersion
-                    || savedDeviceVersion !== deviceClientVersion;
+                    || savedDeviceVersion !== deviceClientVersion
+                    || data.systemConfig.timeZone !== normalizedSystemConfig.timeZone;
                 globalConfig.systemConfig = normalizedSystemConfig;
             }
         }

--- a/core/src/runtime/runtime-state.ts
+++ b/core/src/runtime/runtime-state.ts
@@ -1,22 +1,9 @@
 export {};
 const { EventEmitter } = require('node:events');
+const { getRuntimeConfig } = require('../config/config');
 const { createModuleLogger } = require('../services/logger');
 const { getTodayKey, loadPersistedStats } = require('../services/stats');
-
-function pad2(n: number): string {
-    return String(n).padStart(2, '0');
-}
-
-function formatLocalDateTime24(date: Date = new Date()): string {
-    const d = date instanceof Date ? date : new Date();
-    const y = d.getFullYear();
-    const m = pad2(d.getMonth() + 1);
-    const day = pad2(d.getDate());
-    const hh = pad2(d.getHours());
-    const mm = pad2(d.getMinutes());
-    const ss = pad2(d.getSeconds());
-    return `${y}-${m}-${day} ${hh}:${mm}:${ss}`;
-}
+const { formatSystemDateTime24 } = require('../utils/utils');
 
 interface RuntimeStateOptions {
     store: any;
@@ -74,12 +61,13 @@ function createRuntimeState(options: RuntimeStateOptions) {
         const { ui: _ui, ...accountConfig } = store.getConfigSnapshot(accountId);
         return {
             ...accountConfig,
+            systemTimeZone: getRuntimeConfig().timeZone,
             __revision: configRevision,
         };
     }
 
     function log(tag: string, msg: string, extra: Record<string, any> = {}): void {
-        const time = formatLocalDateTime24(new Date());
+        const time = formatSystemDateTime24();
         const level = tag === '错误' ? 'error' : 'info';
         runtimeLogger[level](msg, { tag, ...extra });
         const moduleName = (tag === '系统' || tag === '错误') ? 'system' : '';
@@ -99,7 +87,7 @@ function createRuntimeState(options: RuntimeStateOptions) {
 
     function addAccountLog(action: string, msg: string, accountId = '', accountName = '', extra: Record<string, any> = {}): void {
         const entry: AccountLogEntry = {
-            time: formatLocalDateTime24(new Date()),
+            time: formatSystemDateTime24(),
             action,
             msg,
             accountId: accountId ? String(accountId) : '',

--- a/core/src/runtime/worker-manager.ts
+++ b/core/src/runtime/worker-manager.ts
@@ -118,14 +118,16 @@ function createWorkerManager(options: WorkerManagerOptions) {
             wsError: null,
         };
 
+        const initialConfigSnapshot = buildConfigSnapshotForAccount(account.id);
         child.send({
             type: 'start',
             config: {
                 code: account.code,
                 platform: account.platform,
+                systemTimeZone: initialConfigSnapshot.systemTimeZone,
             },
         });
-        child.send({ type: 'config_sync', config: buildConfigSnapshotForAccount(account.id) });
+        child.send({ type: 'config_sync', config: initialConfigSnapshot });
 
         child.on('message', (msg: any) => {
             handleWorkerMessage(account.id, child, msg);
@@ -415,6 +417,32 @@ function createWorkerManager(options: WorkerManagerOptions) {
                 if (worker_process && worker_process.process) {
                     worker_process.process.send({ type: 'config_sync', config: buildConfigSnapshotForAccount(accountId) });
                 }
+            }
+        } else if (msg.type === 'known_friend_gids_sync') {
+            const { setKnownFriendGids } = require('../models/store');
+            const gids: number[] = Array.isArray(msg.gids)
+                ? msg.gids.map(Number).filter((gid: number) => Number.isFinite(gid) && gid > 0)
+                : [];
+            const saved: number[] = setKnownFriendGids(accountId, gids);
+            worker.process.send({
+                type: 'config_sync',
+                config: buildConfigSnapshotForAccount(accountId),
+            });
+            log('好友', `已同步并持久化 ${saved.length} 个好友 GID`, {
+                accountId: String(accountId),
+                accountName: worker.name,
+                friendCount: saved.length,
+            });
+        } else if (msg.type === 'known_friend_gid_remove') {
+            const { getKnownFriendGids, setKnownFriendGids } = require('../models/store');
+            const gid: number = Number(msg.gid) || 0;
+            if (gid > 0) {
+                const current: number[] = getKnownFriendGids(accountId);
+                setKnownFriendGids(accountId, current.filter((item: number) => Number(item) !== gid));
+                worker.process.send({
+                    type: 'config_sync',
+                    config: buildConfigSnapshotForAccount(accountId),
+                });
             }
         }
     }

--- a/core/src/services/activity-center.ts
+++ b/core/src/services/activity-center.ts
@@ -7,7 +7,7 @@ const LongModule = require('long');
 const { sendMsgAsync, GatewayError } = require('../utils/network');
 const { types } = require('../utils/proto');
 const { getItemById, getItemImageById } = require('../config/gameConfig');
-const { getServerTimeSec } = require('../utils/utils');
+const { getServerTimeSec, getSystemDateKey } = require('../utils/utils');
 const { getBag, getBagItems } = require('./warehouse');
 const { getActivityWindows } = require('./activity-windows');
 const { buildActivityGameplayBindings, resolveActivityGameplays } = require('./activity-gameplay-registry');
@@ -483,15 +483,6 @@ async function querySolarTerms(): Promise<any> {
     return types.GetSolarTermsReply.decode(replyBody);
 }
 
-function beijingDateKey(): string {
-    return new Intl.DateTimeFormat('en-CA', {
-        timeZone: 'Asia/Shanghai',
-        year: 'numeric',
-        month: '2-digit',
-        day: '2-digit',
-    }).format(new Date());
-}
-
 async function operateQingMei(requestType: any, payload: any, expectedErrorCodes: number[] = []): Promise<any> {
     const body = Buffer.from(requestType.encode(requestType.create(payload)).finish());
     const { body: replyBody } = await sendMsgAsync(
@@ -538,7 +529,7 @@ function qingMeiDto(reply: any, ingredients: any[] | null = null) {
     const quotePrices = (Array.isArray(brew.quote_prices) ? brew.quote_prices : []).map(int64String);
     const quoteTotals = (Array.isArray(brew.quote_totals) ? brew.quote_totals : []).map(int64String);
     const rules = textContent(activity?.extra);
-    const dailySeedClaimed = qingMeiSeedClaimedDateKey === beijingDateKey() || !!dailySeed?.claimed;
+    const dailySeedClaimed = qingMeiSeedClaimedDateKey === getSystemDateKey() || !!dailySeed?.claimed;
     return {
         activityId: int64String(activity?.activity_id) === '0' ? QINGMEI_BREW_ACTIVITY_ID : int64String(activity?.activity_id),
         dailyActivityId: QINGMEI_DAILY_ACTIVITY_ID,
@@ -1091,7 +1082,7 @@ async function claimQingMeiDailySeed() {
             }
             alreadyClaimed = true;
         }
-        qingMeiSeedClaimedDateKey = beijingDateKey();
+        qingMeiSeedClaimedDateKey = getSystemDateKey();
         return {
             rewards: (Array.isArray(reply?.rewards) ? reply.rewards : []).map(itemDto),
             message: alreadyClaimed ? '今日青梅种子已经领取，无需重复领取' : '青梅种子领取成功',

--- a/core/src/services/email.ts
+++ b/core/src/services/email.ts
@@ -5,27 +5,19 @@ export {};
 
 const { sendMsgAsync, sendMsgNoReply } = require('../utils/network');
 const { types } = require('../utils/proto');
-const { log, toNum } = require('../utils/utils');
+const { log, toNum, getSystemDateKey } = require('../utils/utils');
 
 const DAILY_KEY: string = 'email_rewards';
 let doneDateKey: string = '';
 let lastCheckAt: number = 0;
 const CHECK_COOLDOWN_MS: number = 5 * 60 * 1000;
 
-function getDateKey(): string {
-    const now: Date = new Date();
-    const y: number = now.getFullYear();
-    const m: string = String(now.getMonth() + 1).padStart(2, '0');
-    const d: string = String(now.getDate()).padStart(2, '0');
-    return `${y}-${m}-${d}`;
-}
-
 function markDoneToday(): void {
-    doneDateKey = getDateKey();
+    doneDateKey = getSystemDateKey();
 }
 
 function isDoneToday(): boolean {
-    return doneDateKey === getDateKey();
+    return doneDateKey === getSystemDateKey();
 }
 
 async function getEmailList(boxType: number = 1): Promise<any> {

--- a/core/src/services/friend/scheduler.ts
+++ b/core/src/services/friend/scheduler.ts
@@ -5,7 +5,7 @@
 const { CONFIG } = require('../../config/config');
 const crypto = require('node:crypto');
 const { getUserState, networkEvents } = require('../../utils/network');
-const { toNum, getServerTimeSec, log, logWarn, randomDelay } = require('../../utils/utils');
+const { toNum, getSystemDateKey, log, logWarn, randomDelay } = require('../../utils/utils');
 const { getDataFile } = require('../../config/runtime-paths');
 const { createScheduler } = require('../scheduler');
 const { readJsonFile, writeJsonFileAtomic } = require('../json-db');
@@ -64,16 +64,6 @@ const OP_NAMES: Record<number, string> = {
 
 // ============ 操作限制相关 ============
 
-function getBeijingDateKey(): string {
-    const nowSec: number = getServerTimeSec();
-    const nowMs: number = nowSec > 0 ? nowSec * 1000 : Date.now();
-    const bjDate: Date = new Date(nowMs + 8 * 3600 * 1000);
-    const y: number = bjDate.getUTCFullYear();
-    const m: string = String(bjDate.getUTCMonth() + 1).padStart(2, '0');
-    const d: string = String(bjDate.getUTCDate()).padStart(2, '0');
-    return `${y}-${m}-${d}`;
-}
-
 function getBadDailyStateFile(): string {
     const accountId: string = String(process.env.FARM_ACCOUNT_ID || 'default');
     const token: string = crypto.createHash('sha256').update(accountId, 'utf8').digest('hex');
@@ -99,7 +89,7 @@ function persistBadDailyStop(today: string): void {
  * 检查是否需要重置每日限制 (0点刷新)
  */
 export function checkDailyReset(): void {
-    const today: string = getBeijingDateKey();
+    const today: string = getSystemDateKey();
     if (lastResetDate !== today) {
         if (lastResetDate !== '') {
             log('系统', '跨日重置，清空操作限制缓存');
@@ -129,7 +119,7 @@ export function markBadOperationLimitReached(method: string = ''): boolean {
     if (badOperationLimitReached) return false;
     badOperationLimitReached = true;
     try {
-        persistBadDailyStop(lastResetDate || getBeijingDateKey());
+        persistBadDailyStop(lastResetDate || getSystemDateKey());
     } catch (e: any) {
         logWarn('好友', `保存当日捣乱停用状态失败: ${e.message}`);
     }

--- a/core/src/services/friend/visit-strategy.ts
+++ b/core/src/services/friend/visit-strategy.ts
@@ -2,7 +2,7 @@
  * 拜访好友策略 - 访问逻辑、好友分析、错误处理、安静时段
  */
 
-const { CONFIG, PlantPhase, PHASE_NAMES } = require('../../config/config');
+const { PlantPhase, PHASE_NAMES } = require('../../config/config');
 const { getPlantName, getPlantById, getSeedImageBySeedId, getPlantGrowTime } = require('../../config/gameConfig');
 const {
     isAutomationOn,
@@ -12,7 +12,7 @@ const {
     getFriendsListCacheTtlSec,
 } = require('../../models/store');
 const { getUserState } = require('../../utils/network');
-const { toNum, toLong, toTimeSec, getServerTimeSec, log, logWarn, sleep, randomDelay } = require('../../utils/utils');
+const { toNum, toTimeSec, getServerTimeSec, getSystemClockMinutes, log, logWarn, sleep, randomDelay } = require('../../utils/utils');
 const { types } = require('../../utils/proto');
 const { getCurrentPhase, buildLandMap, getDisplayLandContext, isOccupiedSlaveLand } = require('../farm');
 const { recordOperation } = require('../stats');
@@ -228,7 +228,7 @@ export function parseTimeToMinutes(timeStr: string): number | null {
     return h * 60 + min;
 }
 
-export function inFriendQuietHours(now: Date = new Date()): boolean {
+export function inFriendQuietHours(now?: Date): boolean {
     const cfg: any = getFriendQuietHours();
     if (!cfg || !cfg.enabled) return false;
 
@@ -236,7 +236,9 @@ export function inFriendQuietHours(now: Date = new Date()): boolean {
     const end: number | null = parseTimeToMinutes(cfg.end);
     if (start === null || end === null) return false;
 
-    const cur: number = now.getHours() * 60 + now.getMinutes();
+    const cur: number = now instanceof Date
+        ? getSystemClockMinutes(now.getTime())
+        : getSystemClockMinutes();
     if (start === end) return true; // 起止相同视为全天静默
     if (start < end) return cur >= start && cur < end;
     return cur >= start || cur < end; // 跨天时段
@@ -409,13 +411,14 @@ export async function getFriendsList(forceSync: boolean = false): Promise<any[]>
  * 获取指定好友的农田详情 (进入-获取-离开)
  */
 export async function getFriendLandsDetail(friendGid: number): Promise<any> {
+    let entered = false;
     try {
         const enterReply: any = await enterFriendFarm(friendGid);
+        entered = true;
         const lands: any[] = enterReply.lands || [];
         const state: any = getUserState();
         const plantBlacklist: number[] = getPlantBlacklist(state.accountId);
         const analyzed: AnalyzeResult = analyzeFriendLands(lands, state.gid, '', { plantBlacklist });
-        await leaveFriendFarm(friendGid);
 
         const landsList: any[] = [];
         const nowSec: number = getServerTimeSec();
@@ -528,8 +531,8 @@ export async function getFriendLandsDetail(friendGid: number): Promise<any> {
             lands: landsList,
             summary: analyzed,
         };
-    } catch {
-        return { lands: [], summary: {} };
+    } finally {
+        if (entered) await leaveFriendFarm(friendGid);
     }
 }
 

--- a/core/src/services/mall.ts
+++ b/core/src/services/mall.ts
@@ -6,7 +6,7 @@ const { Buffer } = require('node:buffer');
 
 const { sendMsgAsync, getUserState } = require('../utils/network');
 const { types } = require('../utils/proto');
-const { toNum, log, sleep } = require('../utils/utils');
+const { toNum, log, sleep, getSystemDateKey } = require('../utils/utils');
 
 const ORGANIC_FERTILIZER_MALL_GOODS_ID: number = 1002;
 const INORGANIC_FERTILIZER_MALL_GOODS_ID: number = 1003;
@@ -24,14 +24,6 @@ let buyPausedNoGoldDateKey: string = '';
 let freeGiftDoneDateKey: string = '';
 let freeGiftLastAt: number = 0;
 let freeGiftLastCheckAt: number = 0;
-
-function getDateKey(): string {
-    const now = new Date();
-    const y = now.getFullYear();
-    const m = String(now.getMonth() + 1).padStart(2, '0');
-    const d = String(now.getDate()).padStart(2, '0');
-    return `${y}-${m}-${d}`;
-}
 
 async function getMallListBySlotType(slotType: number = 1, subSlotType: number = 0): Promise<any> {
     const body: Uint8Array = types.GetMallListBySlotTypeRequest.encode(types.GetMallListBySlotTypeRequest.create({
@@ -127,7 +119,7 @@ async function autoBuyOrganicFertilizerViaMall(): Promise<number> {
 
     for (let i = 0; i < MAX_ROUNDS; i++) {
         if (singlePrice > 0 && ticket > 0 && ticket < singlePrice) {
-            buyPausedNoGoldDateKey = getDateKey();
+            buyPausedNoGoldDateKey = getSystemDateKey();
             break;
         }
         try {
@@ -151,7 +143,7 @@ async function autoBuyOrganicFertilizerViaMall(): Promise<number> {
                     perRound = 1;
                     continue;
                 }
-                buyPausedNoGoldDateKey = getDateKey();
+                buyPausedNoGoldDateKey = getSystemDateKey();
             }
             break;
         }
@@ -215,7 +207,7 @@ async function autoBuyFertilizerViaMall(type: string = 'organic', targetCount: n
     for (let i = 0; i < MAX_ROUNDS; i++) {
         if (targetCount > 0 && totalBought >= remainingToBuy) break;
         if (singlePrice > 0 && ticket > 0 && ticket < singlePrice) {
-            buyPausedNoGoldDateKey = getDateKey();
+            buyPausedNoGoldDateKey = getSystemDateKey();
             break;
         }
         const buyCount: number = targetCount > 0 ? Math.min(perRound, remainingToBuy - totalBought) : perRound;
@@ -241,7 +233,7 @@ async function autoBuyFertilizerViaMall(type: string = 'organic', targetCount: n
                     perRound = 1;
                     continue;
                 }
-                buyPausedNoGoldDateKey = getDateKey();
+                buyPausedNoGoldDateKey = getSystemDateKey();
             }
             break;
         }
@@ -268,7 +260,7 @@ async function autoBuyOrganicFertilizer(force: boolean = false): Promise<number>
     try {
         const totalBought: number = await autoBuyOrganicFertilizerViaMall();
         if (totalBought > 0) {
-            buyDoneDateKey = getDateKey();
+            buyDoneDateKey = getSystemDateKey();
             buyLastSuccessAt = Date.now();
             log('商城', `自动购买有机化肥 x${totalBought}`, {
                 module: 'warehouse',
@@ -291,7 +283,7 @@ async function autoBuyFertilizer(force: boolean = false, type: string = 'organic
     try {
         const totalBought: number = await autoBuyFertilizerViaMall(type, targetCount);
         if (totalBought > 0) {
-            buyDoneDateKey = getDateKey();
+            buyDoneDateKey = getSystemDateKey();
             buyLastSuccessAt = Date.now();
             const typeName: string = type === 'normal' ? '无机化肥' : '有机化肥';
             log('商城', `自动购买${typeName} x${totalBought}`, {
@@ -309,7 +301,7 @@ async function autoBuyFertilizer(force: boolean = false, type: string = 'organic
 }
 
 function isDoneTodayByKey(key: string): boolean {
-    return String(key || '') === getDateKey();
+    return String(key || '') === getSystemDateKey();
 }
 
 async function buyFreeGifts(force: boolean = false): Promise<number> {
@@ -322,7 +314,7 @@ async function buyFreeGifts(force: boolean = false): Promise<number> {
         const goods: any[] = await getMallGoodsList(1);
         const free: any[] = goods.filter((g: any) => !!g && g.is_free === true && Number(g.goods_id || 0) > 0);
         if (!free.length) {
-            freeGiftDoneDateKey = getDateKey();
+            freeGiftDoneDateKey = getSystemDateKey();
             log('商城', '今日暂无可领取免费礼包', {
                 module: 'task',
                 event: FREE_GIFTS_DAILY_KEY,
@@ -340,7 +332,7 @@ async function buyFreeGifts(force: boolean = false): Promise<number> {
                 // 单个失败跳过
             }
         }
-        freeGiftDoneDateKey = getDateKey();
+        freeGiftDoneDateKey = getSystemDateKey();
         if (bought > 0) {
             freeGiftLastAt = Date.now();
             log('商城', `自动购买免费礼包 x${bought}`, {
@@ -497,13 +489,13 @@ module.exports = {
     buyFreeGifts,
     getFertilizerBuyDailyState: () => ({
         key: 'fertilizer_buy',
-        doneToday: buyDoneDateKey === getDateKey(),
-        pausedNoGoldToday: buyPausedNoGoldDateKey === getDateKey(),
+        doneToday: buyDoneDateKey === getSystemDateKey(),
+        pausedNoGoldToday: buyPausedNoGoldDateKey === getSystemDateKey(),
         lastSuccessAt: buyLastSuccessAt,
     }),
     getFreeGiftDailyState: () => ({
         key: FREE_GIFTS_DAILY_KEY,
-        doneToday: freeGiftDoneDateKey === getDateKey(),
+        doneToday: freeGiftDoneDateKey === getSystemDateKey(),
         lastCheckAt: freeGiftLastCheckAt,
         lastClaimAt: freeGiftLastAt,
     }),

--- a/core/src/services/monthcard.ts
+++ b/core/src/services/monthcard.ts
@@ -5,7 +5,7 @@ export {};
 
 const { sendMsgAsync } = require('../utils/network');
 const { types } = require('../utils/proto');
-const { log, toNum } = require('../utils/utils');
+const { log, toNum, getSystemDateKey } = require('../utils/utils');
 
 const DAILY_KEY: string = 'month_card_gift';
 const CHECK_COOLDOWN_MS: number = 10 * 60 * 1000;
@@ -17,20 +17,12 @@ let lastResult: string = '';
 let lastHasCard: boolean | null = null;
 let lastHasClaimable: boolean | null = null;
 
-function getDateKey(): string {
-    const now = new Date();
-    const y = now.getFullYear();
-    const m = String(now.getMonth() + 1).padStart(2, '0');
-    const d = String(now.getDate()).padStart(2, '0');
-    return `${y}-${m}-${d}`;
-}
-
 function markDoneToday(): void {
-    doneDateKey = getDateKey();
+    doneDateKey = getSystemDateKey();
 }
 
 function isDoneToday(): boolean {
-    return doneDateKey === getDateKey();
+    return doneDateKey === getSystemDateKey();
 }
 
 function getRewardSummary(items: any[]): string {

--- a/core/src/services/qqvip.ts
+++ b/core/src/services/qqvip.ts
@@ -5,7 +5,7 @@ export {};
 
 const { sendMsgAsync } = require('../utils/network');
 const { types } = require('../utils/proto');
-const { log, toNum } = require('../utils/utils');
+const { log, toNum, getSystemDateKey } = require('../utils/utils');
 
 const DAILY_KEY: string = 'vip_daily_gift';
 const CHECK_COOLDOWN_MS: number = 10 * 60 * 1000;
@@ -17,20 +17,12 @@ let lastResult: string = '';
 let lastHasGift: boolean | null = null;
 let lastCanClaim: boolean | null = null;
 
-function getDateKey(): string {
-    const now = new Date();
-    const y = now.getFullYear();
-    const m = String(now.getMonth() + 1).padStart(2, '0');
-    const d = String(now.getDate()).padStart(2, '0');
-    return `${y}-${m}-${d}`;
-}
-
 function markDoneToday(): void {
-    doneDateKey = getDateKey();
+    doneDateKey = getSystemDateKey();
 }
 
 function isDoneToday(): boolean {
-    return doneDateKey === getDateKey();
+    return doneDateKey === getSystemDateKey();
 }
 
 function getRewardSummary(items: any[]): string {
@@ -109,6 +101,7 @@ async function performDailyVipGift(force: boolean = false): Promise<boolean> {
             event: DAILY_KEY,
             result: 'ok',
             count: items.length,
+            rewardTypes,
         });
         lastClaimAt = Date.now();
         markDoneToday();

--- a/core/src/services/share.ts
+++ b/core/src/services/share.ts
@@ -5,7 +5,7 @@ export {};
 
 const { sendMsgAsync, sendMsgNoReply } = require('../utils/network');
 const { types } = require('../utils/proto');
-const { log } = require('../utils/utils');
+const { log, getSystemDateKey } = require('../utils/utils');
 
 const DAILY_KEY: string = 'daily_share';
 const CHECK_COOLDOWN_MS: number = 10 * 60 * 1000;
@@ -19,16 +19,8 @@ let lastClaimAt: number = 0;
 let checkStatus: ShareCheckStatus = 'unchecked';
 let canShare: boolean | null = null;
 
-function getDateKey(): string {
-    const now = new Date();
-    const y = now.getFullYear();
-    const m = String(now.getMonth() + 1).padStart(2, '0');
-    const d = String(now.getDate()).padStart(2, '0');
-    return `${y}-${m}-${d}`;
-}
-
 function isCheckedToday(): boolean {
-    return checkedDateKey === getDateKey();
+    return checkedDateKey === getSystemDateKey();
 }
 
 function isAlreadyClaimedError(error: any): boolean {
@@ -74,14 +66,14 @@ async function reportActivityShare(source: number, scene: number): Promise<void>
 
 async function checkDailyShareStatus(force: boolean = false): Promise<boolean> {
     const now: number = Date.now();
-    if (claimedDateKey === getDateKey()) return false;
+    if (claimedDateKey === getSystemDateKey()) return false;
     if (!force && now - lastCheckAt < CHECK_COOLDOWN_MS) return false;
     lastCheckAt = now;
     try {
         const reply: any = await checkCanShare();
         canShare = !!(reply && reply.can_share);
         checkStatus = canShare ? 'entry_available' : 'entry_unavailable';
-        checkedDateKey = getDateKey();
+        checkedDateKey = getSystemDateKey();
         if (!canShare) {
             log('分享', '分享入口暂不可用', {
                 module: 'task',
@@ -107,7 +99,7 @@ async function checkDailyShareStatus(force: boolean = false): Promise<boolean> {
         return true;
     } catch (e: any) {
         if (isAlreadyClaimedError(e)) {
-            claimedDateKey = getDateKey();
+            claimedDateKey = getSystemDateKey();
             checkedDateKey = claimedDateKey;
             lastClaimAt = Date.now();
             checkStatus = 'already_claimed';
@@ -139,7 +131,7 @@ module.exports = {
         checkedToday: isCheckedToday(),
         checkStatus,
         canShare,
-        doneToday: claimedDateKey === getDateKey(),
+        doneToday: claimedDateKey === getSystemDateKey(),
         lastCheckAt,
         lastClaimAt,
     }),

--- a/core/src/services/stats.ts
+++ b/core/src/services/stats.ts
@@ -1,17 +1,14 @@
 export {};
 const path = require('node:path');
 const fs = require('node:fs');
+const { getSystemDateKey } = require('../utils/utils');
 function getStatsFilePath(accountId: string): string {
     const dataDir: string = process.env.FARM_DATA_DIR || path.join(__dirname, '../../data');
     return path.join(dataDir, 'stats', `${accountId}.json`);
 }
 
 function getTodayKey(): string {
-    const now: Date = new Date();
-    const y: number = now.getFullYear();
-    const m: string = String(now.getMonth() + 1).padStart(2, '0');
-    const d: string = String(now.getDate()).padStart(2, '0');
-    return `${y}-${m}-${d}`;
+    return getSystemDateKey();
 }
 
 function loadPersistedStats(accountId: string): any {

--- a/core/src/services/task.ts
+++ b/core/src/services/task.ts
@@ -6,7 +6,7 @@ export {};
 const { isAutomationOn } = require('../models/store');
 const { sendMsgAsync, networkEvents } = require('../utils/network');
 const { types } = require('../utils/proto');
-const { toLong, toNum, log, logWarn, sleep } = require('../utils/utils');
+const { toLong, toNum, log, logWarn, sleep, getSystemDateKey } = require('../utils/utils');
 const { createScheduler } = require('./scheduler');
 const { recordOperation } = require('./stats');
 
@@ -14,18 +14,6 @@ let checking: boolean = false;
 let taskClaimDoneDateKey: string = '';
 let taskClaimLastAt: number = 0;
 const taskScheduler: any = createScheduler('task');
-
-function getDateKey(): string {
-    const { getServerTimeSec } = require('../utils/utils');
-    const nowSec: number = getServerTimeSec();
-    const nowMs: number = nowSec > 0 ? nowSec * 1000 : Date.now();
-    const bjOffset: number = 8 * 3600 * 1000;
-    const bjDate = new Date(nowMs + bjOffset);
-    const y: number = bjDate.getUTCFullYear();
-    const m: string = String(bjDate.getUTCMonth() + 1).padStart(2, '0');
-    const d: string = String(bjDate.getUTCDate()).padStart(2, '0');
-    return `${y}-${m}-${d}`;
-}
 
 // ============ 任务 API ============
 
@@ -229,7 +217,7 @@ async function checkAndClaimIllustratedRewards(): Promise<boolean> {
             scope: 'illustrated',
             count: items.length,
         });
-        taskClaimDoneDateKey = getDateKey();
+        taskClaimDoneDateKey = getSystemDateKey();
         taskClaimLastAt = Date.now();
         recordOperation('taskClaim', 1);
         return true;
@@ -298,7 +286,7 @@ async function doClaim(task: any): Promise<boolean> {
         log('任务', `领取(${categoryName}): ${task.desc}${multipleStr} → ${rewardStr}`, {
             module: 'task', event: '领取任务', result: 'ok', taskId: task.id, shared: useShare
         });
-        taskClaimDoneDateKey = getDateKey();
+        taskClaimDoneDateKey = getSystemDateKey();
         taskClaimLastAt = Date.now();
         recordOperation('taskClaim', 1);
         await sleep(300);
@@ -369,7 +357,7 @@ module.exports = {
     normalizeTaskInfo,
     getTaskClaimDailyState: () => ({
         key: 'task_claim',
-        doneToday: taskClaimDoneDateKey === getDateKey(),
+        doneToday: taskClaimDoneDateKey === getSystemDateKey(),
         lastClaimAt: taskClaimLastAt,
     }),
     getTaskDailyStateLikeApp: async () => {

--- a/core/src/services/warehouse.ts
+++ b/core/src/services/warehouse.ts
@@ -9,7 +9,7 @@ const { getFruitName, getPlantByFruitId, getPlantBySeedId, getItemById, getItemI
 const { isAutomationOn } = require('../models/store');
 const { sendMsgAsync, networkEvents, getUserState } = require('../utils/network');
 const { types } = require('../utils/proto');
-const { toLong, toNum, toTimeSec, log, logWarn, sleep } = require('../utils/utils');
+const { toLong, toNum, toTimeSec, log, logWarn, sleep, getSystemDateKey } = require('../utils/utils');
 const { getSellConditionContext } = require('./activity-windows');
 const { updateStatusGold } = require('./status');
 
@@ -32,14 +32,6 @@ const ORGANIC_FERTILIZER_ITEM_HOURS: Map<number, number> = new Map([
 let fertilizerGiftDoneDateKey: string = '';
 let fertilizerGiftLastOpenAt: number = 0;
 let pendingBagRequest: Promise<any> | null = null;
-
-function getDateKey(): string {
-    const now = new Date();
-    const y = now.getFullYear();
-    const m = String(now.getMonth() + 1).padStart(2, '0');
-    const d = String(now.getDate()).padStart(2, '0');
-    return `${y}-${m}-${d}`;
-}
 
 // ============ API ============
 
@@ -298,7 +290,7 @@ async function autoOpenFertilizerGiftPacks(): Promise<number> {
         }
 
         if (opened > 0) {
-            fertilizerGiftDoneDateKey = getDateKey();
+            fertilizerGiftDoneDateKey = getSystemDateKey();
             fertilizerGiftLastOpenAt = Date.now();
             log('仓库', `自动使用化肥类道具 x${opened}${details.length ? ` [${details.join('，')}]` : ''}`, {
                 module: 'warehouse',
@@ -667,7 +659,7 @@ module.exports = {
     openFertilizerGiftPacksSilently,
     getFertilizerGiftDailyState: () => ({
         key: 'fertilizer_gift_open',
-        doneToday: fertilizerGiftDoneDateKey === getDateKey(),
+        doneToday: fertilizerGiftDoneDateKey === getSystemDateKey(),
         lastOpenAt: fertilizerGiftLastOpenAt,
     }),
     sellAllFruits,

--- a/core/src/types/config.ts
+++ b/core/src/types/config.ts
@@ -103,6 +103,7 @@ export interface SystemConfig {
   clientVersion: string;
   platform: string;
   os: string;
+  timeZone: string;
   deviceInfo: DeviceInfo;
 }
 

--- a/core/src/utils/utils.ts
+++ b/core/src/utils/utils.ts
@@ -5,12 +5,15 @@ import type Long from 'long';
 export {};
 
 const LongModule = require('long');
+const { CONFIG } = require('../config/config');
 const { createModuleLogger, sanitizeMeta } = require('../services/logger');
 const coreLogger = createModuleLogger('core');
 
 // ============ 服务器时间状态 ============
 let serverTimeMs: number = 0;
 let localTimeAtSync: number = 0;
+const dateFormatters: Map<string, Intl.DateTimeFormat> = new Map();
+const timeFormatters: Map<string, Intl.DateTimeFormat> = new Map();
 
 // ============ 类型转换 ============
 function toLong(val: number | Long): Long {
@@ -35,6 +38,67 @@ function getServerTimeSec(): number {
 function syncServerTime(ms: number): void {
     serverTimeMs = ms;
     localTimeAtSync = Date.now();
+}
+
+function getDateFormatter(timeZone: string): Intl.DateTimeFormat {
+    let formatter = dateFormatters.get(timeZone);
+    if (!formatter) {
+        formatter = new Intl.DateTimeFormat('en-US', {
+            timeZone,
+            year: 'numeric',
+            month: '2-digit',
+            day: '2-digit',
+        });
+        dateFormatters.set(timeZone, formatter);
+    }
+    return formatter;
+}
+
+function getTimeFormatter(timeZone: string): Intl.DateTimeFormat {
+    let formatter = timeFormatters.get(timeZone);
+    if (!formatter) {
+        formatter = new Intl.DateTimeFormat('en-US', {
+            timeZone,
+            hour: '2-digit',
+            minute: '2-digit',
+            second: '2-digit',
+            hourCycle: 'h23',
+        });
+        timeFormatters.set(timeZone, formatter);
+    }
+    return formatter;
+}
+
+function partsToRecord(parts: Intl.DateTimeFormatPart[]): Record<string, string> {
+    const result: Record<string, string> = {};
+    for (const part of parts) {
+        if (part.type !== 'literal') result[part.type] = part.value;
+    }
+    return result;
+}
+
+/** 按指定 IANA 时区生成日期键，不依赖服务器操作系统时区 */
+function formatDateKeyInTimeZone(nowMs: number, timeZone: string): string {
+    const parts = partsToRecord(getDateFormatter(timeZone).formatToParts(new Date(nowMs)));
+    return `${parts.year}-${parts.month}-${parts.day}`;
+}
+
+/** 获取系统配置时区下的当前日期键 */
+function getSystemDateKey(nowMs: number = getServerTimeSec() * 1000): string {
+    return formatDateKeyInTimeZone(nowMs, CONFIG.timeZone);
+}
+
+/** 获取系统配置时区下的当前分钟数（0-1439） */
+function getSystemClockMinutes(nowMs: number = getServerTimeSec() * 1000): number {
+    const parts = partsToRecord(getTimeFormatter(CONFIG.timeZone).formatToParts(new Date(nowMs)));
+    return Number(parts.hour) * 60 + Number(parts.minute);
+}
+
+/** 按系统配置时区格式化日志时间 */
+function formatSystemDateTime24(nowMs: number = Date.now()): string {
+    const date = formatDateKeyInTimeZone(nowMs, CONFIG.timeZone);
+    const parts = partsToRecord(getTimeFormatter(CONFIG.timeZone).formatToParts(new Date(nowMs)));
+    return `${date} ${parts.hour}:${parts.minute}:${parts.second}`;
 }
 
 /**
@@ -149,6 +213,7 @@ function randomDelay(minMs: number, maxMs: number): Promise<void> {
 module.exports = {
     toLong, toNum,
     setLogHook,
-    getServerTimeSec, syncServerTime, toTimeSec,
+    getServerTimeSec, syncServerTime, getSystemDateKey, getSystemClockMinutes,
+    formatDateKeyInTimeZone, formatSystemDateTime24, toTimeSec,
     log, logWarn, sleep, randomDelay,
 };

--- a/web/src/views/Settings.vue
+++ b/web/src/views/Settings.vue
@@ -1106,6 +1106,7 @@ const localSystemConfig = ref({
   clientVersion: '',
   platform: 'qq',
   os: 'Windows',
+  timeZone: 'Asia/Shanghai',
   deviceInfo: { ...defaultDeviceInfo },
 })
 const defaultSystemConfig = ref({
@@ -1113,10 +1114,14 @@ const defaultSystemConfig = ref({
   clientVersion: '',
   platform: 'qq',
   os: 'Windows',
+  timeZone: 'Asia/Shanghai',
   deviceInfo: { ...defaultDeviceInfo },
 })
 const devicePresets = ref<any[]>([])
 const selectedPresetId = ref('')
+const timeZoneOptions = ref([
+  { label: '北京时间 / 上海（UTC+8）', value: 'Asia/Shanghai' },
+])
 const platformOptions = [
   { label: 'QQ', value: 'qq' },
   { label: '微信', value: 'wx' },
@@ -1133,6 +1138,7 @@ function normalizeSystemConfig(source: any, fallback: any) {
     clientVersion: source?.clientVersion || '',
     platform: source?.platform || 'qq',
     os: source?.os || 'Windows',
+    timeZone: source?.timeZone || fallback.timeZone || 'Asia/Shanghai',
     deviceInfo: source?.deviceInfo ? { ...fallback.deviceInfo, ...source.deviceInfo } : { ...fallback.deviceInfo },
   }
 }
@@ -1167,6 +1173,12 @@ async function loadSystemConfig() {
   try {
     const { data } = await api.get('/api/settings/system-config')
     if (data?.ok) {
+      if (Array.isArray(data.data.timeZones) && data.data.timeZones.length) {
+        timeZoneOptions.value = data.data.timeZones.map((option: any) => ({
+          label: String(option.label || option.value || ''),
+          value: String(option.value || 'Asia/Shanghai'),
+        }))
+      }
       defaultSystemConfig.value = normalizeSystemConfig(data.data.default, defaultSystemConfig.value)
       localSystemConfig.value = normalizeSystemConfig(data.data.saved || data.data.default, defaultSystemConfig.value)
     }
@@ -1874,6 +1886,17 @@ async function handleResetSystemConfig() {
                   type="text"
                   placeholder="wss://..."
                 />
+
+                <div>
+                  <BaseSelect
+                    v-model="localSystemConfig.timeZone"
+                    label="系统时区"
+                    :options="timeZoneOptions"
+                  />
+                  <p class="mt-1.5 text-xs text-gray-500 dark:text-gray-400">
+                    每日礼包、好友额度、任务统计、安静时段和日志时间均以此时区为准；推荐使用北京时间 / 上海。
+                  </p>
+                </div>
 
                 <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
                   <div class="flex flex-col gap-1.5">


### PR DESCRIPTION
## 背景

跨日重置逻辑目前散落在各个服务里，各自实现且互相不一致：

| 位置 | 当前实现 |
| --- | --- |
| `services/email.ts`、`qqvip.ts`、`monthcard.ts`、`mall.ts`、`warehouse.ts` | `new Date()` 取**宿主机本地日期** |
| `services/task.ts`、`services/friend/scheduler.ts` | 服务器时间 `+8h` **硬编码北京时间** |
| `services/activity-center.ts` | 单独用 `Intl` 按 `Asia/Shanghai` 格式化 |
| `core/worker.ts`、`runtime/runtime-state.ts` | 各自实现一份 `formatLocalDateTime24` |

宿主机时区不是 UTC+8 时（海外 VPS、Docker 默认 UTC），每日邮件、会员礼包、月卡、
任务领取、好友捣乱次数会在错误的时刻重置，日志时间戳也和游戏内时间对不上。

## 改动

**1. 时区统一**

- 新增 `SystemConfig.timeZone`，白名单 10 个常用 IANA 时区，默认 `Asia/Shanghai`；
  非白名单值回落默认值，旧配置自动迁移。
- 后台「系统配置」增加时区下拉框，保存后通过已有的 `broadcastConfig` 热同步到各 worker，
  worker 启动时也随首个配置快照下发，无需重启账号。
- `utils` 新增 `getSystemDateKey` / `getSystemClockMinutes` / `formatSystemDateTime24`，
  基于**服务器时间 + 配置时区**计算（`Intl.DateTimeFormat` 实例做了缓存），
  替换上面表格里所有各自为政的实现。
- 好友静默时段改用配置时区的分钟数判断。

**2. 好友 GID 持久化**

worker 侧 `services/friend/gid-manager.ts` 会向主进程发 `known_friend_gids_sync` 与
`known_friend_gid_remove`，但 `runtime/worker-manager.ts` 从未注册这两类消息的处理，
消息被静默丢弃，GID 始终不落盘、账号重启后丢失。本 PR 补上处理并回推配置快照。

**3. 好友农场未退出**

`getFriendLandsDetail` 解析土地信息抛错时不会执行 `leaveFriendFarm`，会话残留在好友农场；
且外层 `catch` 把异常吞掉返回 `{ lands: [], summary: {} }`，前端只能看到空白、无法区分
"没有土地"和"请求失败"。改为 `try/finally` 保证退出，异常向上抛给已有的错误处理。

## 兼容性

- 默认行为与现在完全一致（默认时区就是 `Asia/Shanghai`），不改任何协议。
- 不新增依赖，不改好友获取路径。

## 验证

- `pnpm -C core run build:ts` ✅
- `node --test core/tests/*.test.js` → 12/12 通过 ✅
- `pnpm typecheck:web` ✅
- diff 无行尾噪声：`git diff --numstat` 与 `git diff --numstat --ignore-cr-at-eol` 结果一致

## 说明

本 PR 与 #41 / #42 是同一批修复的重新整理版（那两个我自己关掉了）：这次去掉了行尾差异噪声、
去掉了与功能无关的改动，并按主题拆开。功能性的新增（鹊羽灵露、好友互动道具）单独放在另一个 PR，
两者互不依赖，可以独立合并。若两个都合，`services/activity-center.ts` 顶部 import 处会有一个
两行的小冲突，我可以随时 rebase。
