### PR TITLE
feat: 新增鹊羽灵露与好友特殊互动道具，并修正鹊桥协议字段

### DIFF
--- a/core/src/controllers/admin/activity-center-routes.ts
+++ b/core/src/controllers/admin/activity-center-routes.ts
@@ -22,9 +22,18 @@ const ACTIVITY_ERROR_MESSAGES: Record<string, string> = {
     QIXI_GIFT_UNAVAILABLE: '当前无法赠送鹊羽香囊',
     INSUFFICIENT_QIXI_SACHET: '鹊羽香囊数量不足',
     INVALID_QIXI_FRIEND_GID: '好友 GID 必须是正十进制整数',
-    INVALID_QIXI_SACHET_COUNT: '赠送数量必须是正十进制整数',
+    INVALID_QIXI_MESSAGE_TEXT_ID: '祝福文案信息无效，请刷新活动后重试',
     QIXI_RESPONSE_INVALID: '鹊桥活动数据已经变化，请刷新页面后重试',
     QIXI_GIFT_FAILED: '鹊羽香囊赠送失败，请刷新后重试',
+    QIXI_DEW_ACCOUNT_UNAVAILABLE: '当前账号 GID 尚未就绪，请稍后重试',
+    INVALID_QIXI_DEW_HOST_GID: '农场主人 GID 无效，请重新选择',
+    INVALID_QIXI_DEW_LAND_ID: '地块信息无效，请刷新后重选',
+    INVALID_QIXI_DEW_LAND_IDS: '请选择有效地块，单次最多选择 48 块',
+    QIXI_DEW_UNAVAILABLE: '活动未进行，鹊羽灵露当前不可使用',
+    INSUFFICIENT_QIXI_DEW: '背包中没有可用的鹊羽灵露',
+    QIXI_DEW_SELECTION_EXCEEDS_BALANCE: '所选地块数量超过当前鹊羽灵露余额',
+    QIXI_DEW_HOST_MISMATCH: '进入的农场与所选好友不一致，请刷新后重试',
+    QIXI_DEW_TARGET_UNAVAILABLE: '所选地块已不再可用，请刷新后重选',
 };
 
 function activityErrorResponse(error: any): { code: string; message: string } {
@@ -109,6 +118,10 @@ function mountActivityCenterRoutes(app: Application, ctx: AdminContext): void {
     mountGet('/api/activity-center/qingmei', 'getCurrentQingMeiActivity');
     mountGet('/api/activity-center/qixi', 'getCurrentQixiActivity');
 
+    app.get('/api/activity-center/qixi/dew/targets', withAccount((accountId: string, req: Request) => (
+        ctx.provider.getQixiDewTargets(accountId, req.query?.hostGid)
+    )));
+
     app.post('/api/activity-center/pass/claim', withAccount((accountId: string) => (
         ctx.provider.claimBattlePassRewards(accountId)
     )));
@@ -151,7 +164,15 @@ function mountActivityCenterRoutes(app: Application, ctx: AdminContext): void {
     )));
 
     app.post('/api/activity-center/qixi/gift', withAccount((accountId: string, req: Request) => (
-        ctx.provider.giftQixiSachet(accountId, req.body?.friendGid, req.body?.count)
+        ctx.provider.giftQixiSachet(accountId, req.body?.friendGid, req.body?.messageTextId ?? 15)
+    )));
+
+    app.post('/api/activity-center/qixi/dew/use', withAccount((accountId: string, req: Request) => (
+        ctx.provider.useQixiDew(accountId, req.body?.hostGid, req.body?.landId)
+    )));
+
+    app.post('/api/activity-center/qixi/dew/use-batch', withAccount((accountId: string, req: Request) => (
+        ctx.provider.useQixiDewBatch(accountId, req.body?.hostGid, req.body?.landIds)
     )));
 }
 

--- a/core/src/controllers/admin/friend-routes.ts
+++ b/core/src/controllers/admin/friend-routes.ts
@@ -12,7 +12,6 @@ const store = require('../../models/store');
 const {
     getAccId,
     handleApiError,
-    getAccountList,
     buildKnownFriendGidSettings,
 } = require('./middleware');
 
@@ -71,6 +70,37 @@ function mountFriendRoutes(app: Application, ctx: AdminContext): void {
         }
     });
 
+    // API: 背包中当前可用于好友土地的特殊互动道具。
+    app.get('/api/friend-interaction-items', async (req: Request, res: Response) => {
+        const id = getAccId(ctx, req);
+        if (!id) return res.status(400).json({ ok: false, error: 'Missing x-account-id' });
+
+        try {
+            const data = await ctx.provider.getFriendInteractionItems(id);
+            res.json({ ok: true, data });
+        } catch (e: any) {
+            handleApiError(res, e);
+        }
+    });
+
+    // API: 在同一次好友访问会话内，按地块编号顺序使用特殊互动道具。
+    app.post('/api/friend/:gid/interaction-items/use-batch', async (req: Request, res: Response) => {
+        const id = getAccId(ctx, req);
+        if (!id) return res.status(400).json({ ok: false, error: 'Missing x-account-id' });
+
+        try {
+            const data = await ctx.provider.useFriendInteractionItemBatch(
+                id,
+                req.params.gid,
+                req.body?.itemId,
+                req.body?.landIds,
+            );
+            res.json({ ok: true, data });
+        } catch (e: any) {
+            handleApiError(res, e);
+        }
+    });
+
     // API: 对指定好友执行单次操作（偷菜/浇水/除草/捣乱）
     app.post('/api/friend/:gid/op', async (req: Request, res: Response) => {
         const id = getAccId(ctx, req);
@@ -98,7 +128,7 @@ function mountFriendRoutes(app: Application, ctx: AdminContext): void {
             if (ctx.provider && typeof ctx.provider.getFriends === 'function') {
                 friendsList = await ctx.provider.getFriends(id) || [];
             }
-        } catch (e) {
+        } catch {
             // 忽略获取好友列表失败
         }
 
@@ -153,7 +183,7 @@ function mountFriendRoutes(app: Application, ctx: AdminContext): void {
             if (ctx.provider && typeof ctx.provider.getFriends === 'function') {
                 friendsList = await ctx.provider.getFriends(id) || [];
             }
-        } catch (e) {
+        } catch {
             // 忽略获取好友列表失败
         }
 

--- a/core/src/core/worker.ts
+++ b/core/src/core/worker.ts
@@ -697,6 +697,12 @@ async function handleApiCall(msg: any): Promise<void> {
             case 'getFriendLands':
                 result = await getFriendLandsDetail(args[0]);
                 break;
+            case 'getFriendInteractionItems':
+                result = await require('../services/friend-interaction-items').getFriendInteractionItems();
+                break;
+            case 'useFriendInteractionItemBatch':
+                result = await require('../services/friend-interaction-items').useFriendInteractionItemBatch(args[0], args[1], args[2]);
+                break;
             case 'doFriendOp':
                 result = await doFriendOperation(args[0], args[1]);
                 break;
@@ -806,6 +812,15 @@ async function handleApiCall(msg: any): Promise<void> {
                 break;
             case 'giftQixiSachet':
                 result = await require('../services/activity-center').giftQixiSachet(args[0], args[1]);
+                break;
+            case 'getQixiDewTargets':
+                result = await require('../services/qixi-dew').getQixiDewTargets(args[0]);
+                break;
+            case 'useQixiDew':
+                result = await require('../services/qixi-dew').useQixiDew(args[0], args[1]);
+                break;
+            case 'useQixiDewBatch':
+                result = await require('../services/qixi-dew').useQixiDewBatch(args[0], args[1]);
                 break;
             case 'getMallCatalog':
                 result = await require('../services/commerce').getMallCatalog(args[0], args[1]);

--- a/core/src/proto/activitypb.proto
+++ b/core/src/proto/activitypb.proto
@@ -142,17 +142,17 @@ message QixiBridgeConfig {
 }
 
 message QixiGiftExchange {
-    ActivityItem sent_item = 1;
-    ActivityItem received_item = 2;
-    bool field_3 = 3;
-    bool enabled = 4;
+    repeated ActivityItem cost_items = 1;
+    repeated ActivityItem receive_items = 2;
+    int64 gift_type = 3;
+    int64 content = 4;
 }
 
 message QixiGiftProgress {
-    int64 sent_count = 1;
-    int64 field_2 = 2;
-    int64 field_3 = 3;
-    QixiGiftExchange exchange = 4;
+    int64 total_send_count = 1;
+    int64 total_send_limit = 2;
+    int64 total_receive_limit = 3;
+    repeated QixiGiftExchange gifts = 4;
 }
 
 message QingMeiBrewStarted {
@@ -231,7 +231,7 @@ message SettleQingMeiBrewRequest {
 }
 
 message ClaimQixiBridgeRewardsRequest {
-    message Params { int64 claim_mode = 1; }
+    message Params { int64 step = 1; }
     int64 activity_id = 1;
     int64 operate_type = 2;
     Params params = 125;
@@ -239,8 +239,8 @@ message ClaimQixiBridgeRewardsRequest {
 
 message GiftQixiSachetRequest {
     message Params {
-        int64 friend_gid = 1;
-        int64 count = 2;
+        int64 target_gid = 1;
+        int64 msg_text_id = 2;
     }
     int64 activity_id = 1;
     int64 operate_type = 2;
@@ -248,12 +248,13 @@ message GiftQixiSachetRequest {
 }
 
 message QixiGiftResult {
-    bool success = 1;
+    int64 total_send_count = 1;
 }
 
 message QixiBridgeRewardResult {
-    repeated int64 claimed_stages = 1 [packed = true];
-    repeated corepb.Item rewards = 2;
+    repeated int64 unlocked_steps = 1 [packed = true];
+    repeated corepb.Item awards = 2;
+    bool completed = 3;
 }
 
 message ActivityOperateReply {

--- a/core/src/proto/itempb.proto
+++ b/core/src/proto/itempb.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package gamepb.itempb;
 
 import "corepb.proto";
+import "plantpb.proto";
 
 // ============ 背包/仓库 ============
 
@@ -28,10 +29,24 @@ message SellReply {
 
 message UseRequest {
     corepb.Item item = 1;
+    UseTarget target = 2;
+}
+
+message UseTarget {
+    int64 host_gid = 1;
+    repeated int64 land_ids = 2 [packed = true];
+    int64 use_config_id = 3;
 }
 
 message UseReply {
     repeated corepb.Item used_items = 1;
+    repeated corepb.Item items = 2;
+    gamepb.plantpb.LandInfo land = 4;
+    UseLandReward land_reward = 5;
+}
+
+message UseLandReward {
+    int64 land_id = 1;
     repeated corepb.Item items = 2;
 }
 

--- a/core/src/proto/plantpb.proto
+++ b/core/src/proto/plantpb.proto
@@ -44,18 +44,18 @@ message LandInfo {
     }
 }
 
-// 土地解锁条件 (简化)
+// 土地解锁条件
 message LandUnlockCondition {
-    int64 need_level = 1;
-    int64 need_gold = 2;
-    // ... 其他条件字段
+    int64 preceding_land_id = 1;
+    int64 need_level = 2;
+    int64 need_gold = 3;
 }
 
 // 土地升级条件 (简化)
 message LandUpgradeCondition {
-    int64 need_level = 1;
-    int64 need_gold = 2;
-    // ... 其他条件字段
+    int64 condition_type = 1;
+    int64 condition_value = 2; // condition_type=1 时已确认代表所需角色等级
+    repeated corepb.Item required_items = 3;
 }
 
 // ============ 偷菜玩家信息 ============

--- a/core/src/runtime/data-provider.ts
+++ b/core/src/runtime/data-provider.ts
@@ -117,6 +117,12 @@ function createDataProvider(options: DataProviderOptions) {
         clearFriendsCache: (accountRef: string) => callWorkerApi(resolveAccountRefId(accountRef), 'clearFriendsCache'),
         getInteractRecords: (accountRef: string) => callWorkerApi(resolveAccountRefId(accountRef), 'getInteractRecords'),
         getFriendLands: (accountRef: string, gid: number) => callWorkerApi(resolveAccountRefId(accountRef), 'getFriendLands', gid),
+        getFriendInteractionItems: (accountRef: string) => (
+            callWorkerApi(resolveAccountRefId(accountRef), 'getFriendInteractionItems')
+        ),
+        useFriendInteractionItemBatch: (accountRef: string, gid: unknown, itemId: unknown, landIds: unknown) => (
+            callWorkerApi(resolveAccountRefId(accountRef), 'useFriendInteractionItemBatch', gid, itemId, landIds)
+        ),
         doFriendOp: (accountRef: string, gid: number, opType: string) => callWorkerApi(resolveAccountRefId(accountRef), 'doFriendOp', gid, opType),
         getBag: (accountRef: string) => callWorkerApi(resolveAccountRefId(accountRef), 'getBag'),
         getBagSeeds: (accountRef: string) => callWorkerApi(resolveAccountRefId(accountRef), 'getBagSeeds'),
@@ -141,8 +147,17 @@ function createDataProvider(options: DataProviderOptions) {
         continueQingMeiBrew: (accountRef: string) => callWorkerApi(resolveAccountRefId(accountRef), 'continueQingMeiBrew'),
         settleQingMeiBrew: (accountRef: string) => callWorkerApi(resolveAccountRefId(accountRef), 'settleQingMeiBrew'),
         claimQixiBridgeRewards: (accountRef: string) => callWorkerApi(resolveAccountRefId(accountRef), 'claimQixiBridgeRewards'),
-        giftQixiSachet: (accountRef: string, friendGid: unknown, count: unknown) => (
-            callWorkerApi(resolveAccountRefId(accountRef), 'giftQixiSachet', friendGid, count)
+        giftQixiSachet: (accountRef: string, friendGid: unknown, messageTextId: unknown = 15) => (
+            callWorkerApi(resolveAccountRefId(accountRef), 'giftQixiSachet', friendGid, messageTextId)
+        ),
+        getQixiDewTargets: (accountRef: string, hostGid: unknown) => (
+            callWorkerApi(resolveAccountRefId(accountRef), 'getQixiDewTargets', hostGid)
+        ),
+        useQixiDew: (accountRef: string, hostGid: unknown, landId: unknown) => (
+            callWorkerApi(resolveAccountRefId(accountRef), 'useQixiDew', hostGid, landId)
+        ),
+        useQixiDewBatch: (accountRef: string, hostGid: unknown, landIds: unknown) => (
+            callWorkerApi(resolveAccountRefId(accountRef), 'useQixiDewBatch', hostGid, landIds)
         ),
         getMallCatalog: (accountRef: string, slotType: unknown, subSlotType: unknown) => (
             callWorkerApi(resolveAccountRefId(accountRef), 'getMallCatalog', slotType, subSlotType)

--- a/core/src/services/activity-center.ts
+++ b/core/src/services/activity-center.ts
@@ -6,10 +6,10 @@ import constellationCatalog from '../activity-data/constellation-2026072701.json
 const LongModule = require('long');
 const { sendMsgAsync, GatewayError } = require('../utils/network');
 const { types } = require('../utils/proto');
-const { getItemById, getItemImageById } = require('../config/gameConfig');
+const { getItemById, getItemImageById, getEffectiveSellInfo } = require('../config/gameConfig');
 const { getServerTimeSec } = require('../utils/utils');
 const { getBag, getBagItems } = require('./warehouse');
-const { getActivityWindows } = require('./activity-windows');
+const { getActivityWindows, getSellConditionContext } = require('./activity-windows');
 const { buildActivityGameplayBindings, resolveActivityGameplays } = require('./activity-gameplay-registry');
 const { reportActivityShare } = require('./share');
 const {
@@ -47,6 +47,8 @@ const QIXI_GIFT_OPERATE_TYPE = 26;
 const QIXI_FEATHER_ITEM_ID = '1024';
 const QIXI_SACHET_ITEM_ID = '1025';
 const QIXI_RECEIVED_SACHET_ITEM_ID = '1026';
+const QIXI_DEW_ITEM_ID = '301103';
+const QIXI_DEFAULT_GIFT_MESSAGE_TEXT_ID = 15;
 const MAX_SIGNED_INT64 = 9223372036854775807n;
 const SECONDS_PER_DAY = 86400;
 const BEIJING_UTC_OFFSET_SECONDS = 8 * 60 * 60;
@@ -611,7 +613,29 @@ function qixiActivityIsActive(activity: any, serverTime = getServerTimeSec()): b
     return (beginTime <= 0 || serverTime >= beginTime) && (endTime <= 0 || serverTime <= endTime);
 }
 
-function qixiDto(groupReply: any, balances: Map<string, string> | null = null) {
+function configuredSellPrice(item: any, effectiveSellInfo: any) {
+    const effectivePrices = Array.isArray(effectiveSellInfo?.sells) ? effectiveSellInfo.sells : [];
+    const configuredPrices = effectivePrices.length > 0
+        ? effectivePrices
+        : String(item?.cond_sells || item?.sells || '')
+            .split(';')
+            .map((entry: string) => {
+                const [currencyId, price] = entry.split(':');
+                return { currencyId: Number(currencyId) || 0, price: Number(price) || 0 };
+            })
+            .filter((entry: any) => entry.currencyId > 0 && entry.price > 0);
+    const price = configuredPrices[0];
+    if (!price) return null;
+    const currency = itemDto({ item_id: price.currencyId, count: price.price });
+    return {
+        currencyId: String(price.currencyId),
+        amount: String(price.price),
+        currencyName: currency.name,
+        currencyImage: currency.image,
+    };
+}
+
+function qixiDto(groupReply: any, balances: Map<string, string> | null = null, sellContext: any = null) {
     const bridgeChild = findQixiChild(groupReply, QIXI_BRIDGE_ACTIVITY_ID);
     const giftChild = findQixiChild(groupReply, QIXI_GIFT_ACTIVITY_ID);
     const bridgeActivity = bridgeChild?.activity || null;
@@ -646,9 +670,17 @@ function qixiDto(groupReply: any, balances: Map<string, string> | null = null) {
     const featherBalance = balances ? readBalance(QIXI_FEATHER_ITEM_ID) : null;
     const sachetBalance = balances ? readBalance(QIXI_SACHET_ITEM_ID) : null;
     const receivedSachetBalance = balances ? readBalance(QIXI_RECEIVED_SACHET_ITEM_ID) : null;
+    const dewBalance = balances ? readBalance(QIXI_DEW_ITEM_ID) : null;
     const active = qixiActivityIsActive(bridgeActivity);
     const rules = textContent(bridgeActivity.extra);
-    const exchange = gift?.exchange || {};
+    const dewMetadata = getItemById(Number(QIXI_DEW_ITEM_ID));
+    const dewSellInfo = getEffectiveSellInfo(dewMetadata, sellContext || undefined);
+    const giftExchanges = (Array.isArray(gift.gifts) ? gift.gifts : []).map((entry: any) => ({
+        costItems: (Array.isArray(entry?.cost_items) ? entry.cost_items : []).map(itemDto),
+        receiveItems: (Array.isArray(entry?.receive_items) ? entry.receive_items : []).map(itemDto),
+        giftType: int64String(entry?.gift_type),
+        content: int64String(entry?.content),
+    }));
 
     return {
         groupId: QIXI_GROUP_ID,
@@ -665,10 +697,21 @@ function qixiDto(groupReply: any, balances: Map<string, string> | null = null) {
         feather: itemDto({ item_id: QIXI_FEATHER_ITEM_ID, count: featherBalance || '0' }),
         sachet: itemDto({ item_id: QIXI_SACHET_ITEM_ID, count: sachetBalance || '0' }),
         receivedSachet: itemDto({ item_id: QIXI_RECEIVED_SACHET_ITEM_ID, count: receivedSachetBalance || '0' }),
+        dew: {
+            ...itemDto({ item_id: QIXI_DEW_ITEM_ID, count: dewBalance || '0' }),
+            balance: dewBalance,
+            balanceKnown: balances !== null,
+            usable: active && (balances === null || BigInt(dewBalance || '0') > 0n),
+            sellable: !!dewSellInfo.sellable,
+            sellStatus: String(dewSellInfo.status || 'unavailable'),
+            sellCondition: String(dewSellInfo.condition || dewMetadata?.sell_cond || ''),
+            sellPrice: configuredSellPrice(dewMetadata, dewSellInfo),
+        },
         balances: {
             feather: featherBalance,
             sachet: sachetBalance,
             receivedSachet: receivedSachetBalance,
+            dew: dewBalance,
             known: balances !== null,
         },
         bridge: {
@@ -679,15 +722,11 @@ function qixiDto(groupReply: any, balances: Map<string, string> | null = null) {
             displayItems: (Array.isArray(config.display_items) ? config.display_items : []).map(itemDto),
         },
         gift: {
-            sentCount: int64String(gift.sent_count),
-            field2Code: int64String(gift.field_2),
-            field3Code: int64String(gift.field_3),
-            exchange: {
-                sentItem: itemDto(exchange.sent_item),
-                receivedItem: itemDto(exchange.received_item),
-                field3: !!exchange.field_3,
-                enabled: !!exchange.enabled,
-            },
+            sentCount: int64String(gift.total_send_count),
+            sendLimit: int64String(gift.total_send_limit),
+            receiveLimit: int64String(gift.total_receive_limit),
+            exchanges: giftExchanges,
+            messageTextId: String(QIXI_DEFAULT_GIFT_MESSAGE_TEXT_ID),
         },
         actions: {
             bridge: {
@@ -700,6 +739,11 @@ function qixiDto(groupReply: any, balances: Map<string, string> | null = null) {
                 available: active && (balances === null || BigInt(sachetBalance || '0') > 0n),
                 availabilityKnown: balances !== null,
             },
+            dew: {
+                enabled: active && (balances === null || BigInt(dewBalance || '0') > 0n),
+                available: active && (balances === null || BigInt(dewBalance || '0') > 0n),
+                availabilityKnown: balances !== null,
+            },
         },
     };
 }
@@ -707,10 +751,14 @@ function qixiDto(groupReply: any, balances: Map<string, string> | null = null) {
 async function getCurrentQixiActivity() {
     const groupReply = await queryQixiGroupReply();
     let balances: Map<string, string> | null = null;
+    let sellContext: any = null;
     try {
-        balances = readBagBalances(await getBag(), [QIXI_FEATHER_ITEM_ID, QIXI_SACHET_ITEM_ID, QIXI_RECEIVED_SACHET_ITEM_ID]);
+        balances = readBagBalances(await getBag(), [QIXI_FEATHER_ITEM_ID, QIXI_SACHET_ITEM_ID, QIXI_RECEIVED_SACHET_ITEM_ID, QIXI_DEW_ITEM_ID]);
     } catch {}
-    return qixiDto(groupReply, balances);
+    try {
+        sellContext = await getSellConditionContext();
+    } catch {}
+    return qixiDto(groupReply, balances, sellContext);
 }
 
 function findSeasonActivity(seasonReply: any, typeCode: string): any | null {
@@ -1032,6 +1080,7 @@ async function buildActivityCenterSnapshot(shopOverride: any = null) {
         ...buildActions(season, solarTerms, constellation, shop),
         qixiBridge: qixi?.actions?.bridge || { enabled: false, available: false, availabilityKnown: false },
         qixiGift: qixi?.actions?.gift || { enabled: false, available: false, availabilityKnown: false },
+        qixiDew: qixi?.actions?.dew || { enabled: false, available: false, availabilityKnown: false },
     };
     const activityWindows = settledValue(activityListResult) || [];
     return {
@@ -1049,6 +1098,7 @@ async function buildActivityCenterSnapshot(shopOverride: any = null) {
             exchange: actions.exchange.supported,
             qixiBridge: !!qixi,
             qixiGift: !!qixi,
+            qixiDew: !!qixi,
         },
         actions,
         errors: {
@@ -1194,7 +1244,7 @@ async function claimQixiBridgeRewards() {
         const request = types.ClaimQixiBridgeRewardsRequest.create({
             activity_id: activity.bridgeActivityId,
             operate_type: QIXI_BRIDGE_OPERATE_TYPE,
-            params: { claim_mode: 0 },
+            params: { step: 0 },
         });
         const body = Buffer.from(types.ClaimQixiBridgeRewardsRequest.encode(request).finish());
         const { body: replyBody } = await sendMsgAsync(
@@ -1210,12 +1260,13 @@ async function claimQixiBridgeRewards() {
             throw businessError('QIXI_RESPONSE_INVALID', '鹊桥奖励回包的操作类型不匹配');
         }
         const result = reply.qixi_bridge_result;
-        const rewards = (Array.isArray(result?.rewards) ? result.rewards : (Array.isArray(reply.rewards) ? reply.rewards : []))
+        const rewards = (Array.isArray(result?.awards) ? result.awards : (Array.isArray(reply.rewards) ? reply.rewards : []))
             .map(itemDto);
-        const claimedStages = (Array.isArray(result?.claimed_stages) ? result.claimed_stages : []).map(int64String);
+        const claimedStages = (Array.isArray(result?.unlocked_steps) ? result.unlocked_steps : []).map(int64String);
         return {
             claimedStages,
             rewards,
+            completed: !!result?.completed,
             message: claimedStages.length > 0
                 ? `已完成第 ${claimedStages.join('、')} 阶段鹊桥并领取奖励`
                 : '鹊桥奖励领取成功',
@@ -1224,16 +1275,20 @@ async function claimQixiBridgeRewards() {
     });
 }
 
-async function giftQixiSachet(friendGidInput: unknown, countInput: unknown) {
+async function giftQixiSachet(friendGidInput: unknown, messageTextIdInput: unknown = QIXI_DEFAULT_GIFT_MESSAGE_TEXT_ID) {
     const friendGid = positiveDecimal(friendGidInput, 'INVALID_QIXI_FRIEND_GID', 'friendGid');
-    const count = positiveDecimal(countInput, 'INVALID_QIXI_SACHET_COUNT', 'count');
+    const messageTextId = positiveDecimal(
+        messageTextIdInput ?? QIXI_DEFAULT_GIFT_MESSAGE_TEXT_ID,
+        'INVALID_QIXI_MESSAGE_TEXT_ID',
+        'messageTextId',
+    );
 
     return serializeMutation(async () => {
         const activity = await getCurrentQixiActivity();
         if (!activity.actions.gift.enabled) {
             throw businessError('QIXI_GIFT_UNAVAILABLE', '当前无法赠送鹊羽香囊');
         }
-        if (activity.balances.known && BigInt(activity.balances.sachet || '0') < BigInt(count)) {
+        if (activity.balances.known && BigInt(activity.balances.sachet || '0') < 1n) {
             throw businessError('INSUFFICIENT_QIXI_SACHET', '鹊羽香囊数量不足');
         }
 
@@ -1241,8 +1296,8 @@ async function giftQixiSachet(friendGidInput: unknown, countInput: unknown) {
             activity_id: activity.giftActivityId,
             operate_type: QIXI_GIFT_OPERATE_TYPE,
             params: {
-                friend_gid: friendGid,
-                count,
+                target_gid: friendGid,
+                msg_text_id: messageTextId,
             },
         });
         const body = Buffer.from(types.GiftQixiSachetRequest.encode(request).finish());
@@ -1258,13 +1313,12 @@ async function giftQixiSachet(friendGidInput: unknown, countInput: unknown) {
         if (int64String(reply.operate_type) !== String(QIXI_GIFT_OPERATE_TYPE)) {
             throw businessError('QIXI_RESPONSE_INVALID', '鹊羽香囊回包的操作类型不匹配');
         }
-        if (reply.qixi_gift_result && !reply.qixi_gift_result.success) {
-            throw businessError('QIXI_GIFT_FAILED', '鹊羽香囊赠送未成功');
-        }
         return {
             friendGid,
-            count,
-            message: `已向好友 ${friendGid} 赠送 ${count} 个鹊羽香囊`,
+            count: 1,
+            messageTextId,
+            totalSendCount: int64String(reply.qixi_gift_result?.total_send_count),
+            message: `已向好友 ${friendGid} 赠送 1 个鹊羽香囊`,
             snapshot: await getActivityCenterSnapshot(),
         };
     });

--- a/core/src/services/friend-interaction-items.ts
+++ b/core/src/services/friend-interaction-items.ts
@@ -1,0 +1,401 @@
+/** 好友土地特殊互动道具：库存发现、协议适配与顺序批量使用。 */
+
+export {};
+
+const LongModule = require('long');
+const { PlantPhase } = require('../config/config');
+const { getItemById, getItemImageById } = require('../config/gameConfig');
+const { isSellConditionSatisfied } = require('../config/sell-conditions');
+const { sendMsgAsync, GatewayError } = require('../utils/network');
+const { types } = require('../utils/proto');
+const { toNum } = require('../utils/utils');
+const { getSellConditionContext } = require('./activity-windows');
+const { buildLandMap, getCurrentPhase, getDisplayLandContext } = require('./farm/land-analysis');
+const { enterFriendFarm, leaveFriendFarm } = require('./friend/api');
+const { getBag, getBagItems } = require('./warehouse');
+
+const SPECIAL_INTERACTION_TYPE = 'additemuseitem';
+const MAX_BATCH_LANDS = 48;
+const MAX_SIGNED_INT64 = 9223372036854775807n;
+
+class FriendInteractionBusinessError extends Error {
+    code: string;
+
+    constructor(code: string, message: string) {
+        super(message);
+        this.name = 'FriendInteractionBusinessError';
+        this.code = code;
+    }
+}
+
+function businessError(code: string, message: string): FriendInteractionBusinessError {
+    return new FriendInteractionBusinessError(code, message);
+}
+
+function int64String(value: any): string {
+    if (value == null) return '0';
+    if (LongModule.isLong(value)) return value.toString();
+    const text = String(value).trim();
+    return /^-?\d+$/.test(text) ? text : '0';
+}
+
+function positiveDecimal(value: unknown, code: string, fieldName: string): string {
+    const normalized = int64String(value);
+    if (!/^[1-9]\d*$/.test(normalized) || normalized.length > 19 || BigInt(normalized) > MAX_SIGNED_INT64) {
+        throw businessError(code, `${fieldName} 必须是 int64 范围内的正十进制整数`);
+    }
+    return normalized;
+}
+
+function safePositiveNumber(value: unknown, code: string, fieldName: string): number {
+    const normalized = positiveDecimal(value, code, fieldName);
+    const numeric = Number(normalized);
+    if (!Number.isSafeInteger(numeric) || numeric <= 0) {
+        throw businessError(code, `${fieldName} 超出当前客户端可处理范围`);
+    }
+    return numeric;
+}
+
+function normalizeLandIds(value: unknown): string[] {
+    const source = Array.isArray(value) ? value : [value];
+    const unique = new Set<string>();
+    for (const entry of source) {
+        unique.add(positiveDecimal(entry, 'INVALID_FRIEND_INTERACTION_LAND_IDS', 'landIds'));
+    }
+    if (unique.size === 0) {
+        throw businessError('INVALID_FRIEND_INTERACTION_LAND_IDS', '至少选择一块地');
+    }
+    if (unique.size > MAX_BATCH_LANDS) {
+        throw businessError('INVALID_FRIEND_INTERACTION_LAND_IDS', `单次最多选择 ${MAX_BATCH_LANDS} 块地`);
+    }
+    return [...unique].sort((left, right) => {
+        const leftId = BigInt(left);
+        const rightId = BigInt(right);
+        return leftId < rightId ? -1 : leftId > rightId ? 1 : 0;
+    });
+}
+
+function isFriendLandInteractionMetadata(info: any): boolean {
+    if (!info || typeof info !== 'object') return false;
+    if (Number(info.type) !== 23 || Number(info.can_use) <= 0) return false;
+    if (String(info.interaction_type || '').trim().toLowerCase() !== SPECIAL_INTERACTION_TYPE) return false;
+
+    const id = Number(info.id) || 0;
+    if (id === 301101 || id === 301102 || id === 301103) return true;
+
+    // 排除同属 additemuseItem、但描述明确只作用于自己作物的物品。
+    const targetDescription = `${String(info.desc || '')} ${String(info.effectDesc || '')}`;
+    return /好友|他人/.test(targetDescription);
+}
+
+function getStackExpireTime(stack: any): number {
+    return toNum(stack?.expire_time ?? stack?.expireTime);
+}
+
+function isStackSaleConditionSatisfied(info: any, stack: any, baseContext: any): boolean {
+    const condition = String(info?.sell_cond || '').trim();
+    if (!condition) return false;
+    return isSellConditionSatisfied(condition, {
+        ...baseContext,
+        expireTime: getStackExpireTime(stack),
+    });
+}
+
+function eligibleStacksForItem(bagItems: any[], itemId: number, info: any, baseContext: any): any[] {
+    return (Array.isArray(bagItems) ? bagItems : [])
+        .filter((stack: any) => (
+            toNum(stack?.id ?? stack?.item_id) === itemId
+            && toNum(stack?.uid) > 0
+            && toNum(stack?.count) > 0
+        ))
+        .map((stack: any) => ({
+            raw: stack,
+            remaining: Math.max(0, toNum(stack?.count)),
+            expireTime: getStackExpireTime(stack),
+            saleConditionSatisfied: isStackSaleConditionSatisfied(info, stack, baseContext),
+        }))
+        .sort((left: any, right: any) => {
+            const leftExpire = left.expireTime > 0 ? left.expireTime : Number.MAX_SAFE_INTEGER;
+            const rightExpire = right.expireTime > 0 ? right.expireTime : Number.MAX_SAFE_INTEGER;
+            return leftExpire - rightExpire;
+        });
+}
+
+function buildInteractionItemDto(info: any, stacks: any[]): any {
+    const count = stacks.reduce((sum: number, stack: any) => sum + Math.max(0, Number(stack.remaining) || 0), 0);
+    const saleConditionSatisfiedCount = stacks
+        .filter((stack: any) => stack.saleConditionSatisfied)
+        .reduce((sum: number, stack: any) => sum + Math.max(0, Number(stack.remaining) || 0), 0);
+    const expirations = stacks
+        .map((stack: any) => Number(stack.expireTime) || 0)
+        .filter((expireTime: number) => expireTime > 0)
+        .sort((left: number, right: number) => left - right);
+    const itemId = Number(info.id) || 0;
+    return {
+        id: String(itemId),
+        itemId: String(itemId),
+        name: String(info.name || `物品${itemId}`),
+        image: getItemImageById(itemId) || '',
+        count,
+        saleConditionSatisfiedCount,
+        interactionType: String(info.interaction_type || ''),
+        protocol: 'item-use',
+        description: String(info.desc || info.effectDesc || ''),
+        activityId: info.activity_id == null ? '' : String(info.activity_id),
+        sellCondition: String(info.sell_cond || ''),
+        nearestExpireTime: expirations[0] || 0,
+        serverValidationRequired: true,
+    };
+}
+
+async function collectFriendInteractionInventory(): Promise<{ items: any[]; stacksByItemId: Map<number, any[]> }> {
+    const [bagReply, baseContext] = await Promise.all([getBag(), getSellConditionContext()]);
+    const bagItems = getBagItems(bagReply);
+    const itemIds = new Set<number>();
+    for (const stack of (Array.isArray(bagItems) ? bagItems : [])) {
+        const itemId = toNum(stack?.id ?? stack?.item_id);
+        if (itemId > 0 && toNum(stack?.count) > 0) itemIds.add(itemId);
+    }
+
+    const items: any[] = [];
+    const stacksByItemId = new Map<number, any[]>();
+    for (const itemId of itemIds) {
+        const info = getItemById(itemId);
+        if (!isFriendLandInteractionMetadata(info)) continue;
+        const allItemStacks = bagItems.filter((stack: any) => toNum(stack?.id ?? stack?.item_id) === itemId);
+        const stacks = eligibleStacksForItem(allItemStacks, itemId, info, baseContext);
+        const dto = buildInteractionItemDto(info, stacks);
+        if (dto.count <= 0) continue;
+        stacksByItemId.set(itemId, stacks);
+        items.push(dto);
+    }
+
+    items.sort((left: any, right: any) => {
+        if (right.count !== left.count) return right.count - left.count;
+        return Number(left.itemId) - Number(right.itemId);
+    });
+    return { items, stacksByItemId };
+}
+
+async function getFriendInteractionItems(): Promise<any> {
+    const inventory = await collectFriendInteractionInventory();
+    return {
+        items: inventory.items,
+        count: inventory.items.length,
+        serverValidationRequired: true,
+        confirmationRequired: true,
+        message: inventory.items.length > 0
+            ? '特殊互动道具由服务端在实际使用时最终校验'
+            : '背包中暂无可用于好友土地的特殊互动道具',
+    };
+}
+
+function buildTargetLandMap(landsInput: any[]): Map<string, any> {
+    const lands = Array.isArray(landsInput) ? landsInput : [];
+    const landsMap = buildLandMap(lands);
+    const targets = new Map<string, any>();
+    for (const land of lands) {
+        if (!land?.unlocked) continue;
+        const context = getDisplayLandContext(land, landsMap);
+        if (context.occupiedByMaster) continue;
+        const sourceLand = context.sourceLand || land;
+        const landId = toNum(sourceLand?.id);
+        if (landId <= 0 || targets.has(String(landId))) continue;
+        const plant = sourceLand?.plant;
+        if (!plant || !Array.isArray(plant.phases) || plant.phases.length === 0) continue;
+        const currentPhase = getCurrentPhase(plant.phases, false, '');
+        if (toNum(currentPhase?.phase) === PlantPhase.DEAD) continue;
+        targets.set(String(landId), {
+            landId: String(landId),
+            plantId: int64String(plant.id),
+            occupiedLandIds: (Array.isArray(context.occupiedLandIds) ? context.occupiedLandIds : [landId])
+                .map((id: any) => String(toNum(id)))
+                .filter((id: string) => id !== '0'),
+        });
+    }
+    return targets;
+}
+
+function currentStack(stacks: any[]): any | null {
+    return stacks.find((stack: any) => Number(stack.remaining) > 0) || null;
+}
+
+async function sendTargetedItemUse(itemId: number, stack: any, friendGid: string, landId: string): Promise<any> {
+    const request = types.UseRequest.create({
+        item: {
+            id: itemId,
+            count: 1,
+            uid: stack.raw.uid,
+        },
+        target: {
+            host_gid: friendGid,
+            land_ids: [landId],
+            use_config_id: 0,
+        },
+    });
+    const body = Buffer.from(types.UseRequest.encode(request).finish());
+    const { body: replyBody } = await sendMsgAsync('gamepb.itempb.ItemService', 'Use', body);
+    return types.UseReply.decode(replyBody);
+}
+
+function normalizedErrorCode(error: any): string {
+    return String(error?.code || String(error?.message || '').match(/\bcode=(\d+)\b/)?.[1] || 'FRIEND_INTERACTION_USE_FAILED');
+}
+
+function interactionFailure(itemName: string, landId: string, error: any, target: any = null): any {
+    const code = normalizedErrorCode(error);
+    const knownMessages: Record<string, string> = {
+        '1001065': `该地块当前不符合${itemName}的使用条件，作物品级或状态可能已变化`,
+        '1003008': `该好友农场当前已达到${itemName}的使用限制`,
+        FRIEND_INTERACTION_TARGET_UNAVAILABLE: '该地块已经没有可互动的作物',
+    };
+    const serverMessage = String(error?.errorMessage || '').trim();
+    const businessMessage = error instanceof FriendInteractionBusinessError ? String(error.message || '') : '';
+    return {
+        landId,
+        ok: false,
+        code,
+        message: knownMessages[code] || businessMessage || serverMessage || `服务器未接受该地块的${itemName}使用请求`,
+        target,
+    };
+}
+
+function normalizeReplyItems(itemsInput: any[]): any[] {
+    return (Array.isArray(itemsInput) ? itemsInput : []).map((item: any) => ({
+        id: int64String(item?.id ?? item?.item_id),
+        count: int64String(item?.count),
+        landId: int64String(item?.land_id),
+    }));
+}
+
+async function performFriendInteractionItemBatch(friendGidInput: unknown, itemIdInput: unknown, landIdsInput: unknown): Promise<any> {
+    const friendGid = positiveDecimal(friendGidInput, 'INVALID_FRIEND_INTERACTION_GID', 'friendGid');
+    const friendGidNumber = safePositiveNumber(friendGid, 'INVALID_FRIEND_INTERACTION_GID', 'friendGid');
+    const itemId = safePositiveNumber(itemIdInput, 'INVALID_FRIEND_INTERACTION_ITEM_ID', 'itemId');
+    const landIds = normalizeLandIds(landIdsInput);
+    const info = getItemById(itemId);
+    if (!isFriendLandInteractionMetadata(info)) {
+        throw businessError('FRIEND_INTERACTION_ITEM_UNSUPPORTED', '该物品不是可用于好友土地的特殊互动道具');
+    }
+
+    const inventory = await collectFriendInteractionInventory();
+    const stacks = inventory.stacksByItemId.get(itemId) || [];
+    const available = stacks.reduce((sum: number, stack: any) => sum + Math.max(0, Number(stack.remaining) || 0), 0);
+    if (available <= 0) {
+        throw businessError('FRIEND_INTERACTION_ITEM_UNAVAILABLE', `${info.name || `物品${itemId}`}当前没有可提交服务器校验的库存`);
+    }
+    if (landIds.length > available) {
+        throw businessError('FRIEND_INTERACTION_SELECTION_EXCEEDS_BALANCE', `已选择 ${landIds.length} 块地，但当前只有 ${available} 个${info.name || `物品${itemId}`}`);
+    }
+
+    const enterReply = await enterFriendFarm(friendGidNumber);
+    const attempts: any[] = [];
+    try {
+        const actualGid = int64String(enterReply?.basic?.gid);
+        if (actualGid !== '0' && actualGid !== friendGid) {
+            throw businessError('FRIEND_INTERACTION_HOST_MISMATCH', '进入的好友农场与所选 GID 不一致');
+        }
+        const targetMap = buildTargetLandMap(enterReply?.lands || []);
+        for (let index = 0; index < landIds.length; index += 1) {
+            const landId = landIds[index];
+            const target = targetMap.get(landId) || null;
+            if (!target) {
+                attempts.push(interactionFailure(
+                    String(info.name || `物品${itemId}`),
+                    landId,
+                    businessError('FRIEND_INTERACTION_TARGET_UNAVAILABLE', '所选地块已无可互动作物'),
+                ));
+                continue;
+            }
+
+            const stack = currentStack(stacks);
+            if (!stack) {
+                attempts.push(interactionFailure(
+                    String(info.name || `物品${itemId}`),
+                    landId,
+                    businessError('FRIEND_INTERACTION_ITEM_DEPLETED', '本次可用库存已经用完'),
+                    target,
+                ));
+                continue;
+            }
+
+            try {
+                const reply = await sendTargetedItemUse(itemId, stack, friendGid, landId);
+                stack.remaining -= 1;
+                attempts.push({
+                    landId,
+                    ok: true,
+                    code: '',
+                    message: `第 ${landId} 块地使用成功`,
+                    target,
+                    updatedLand: reply?.land || null,
+                    consumed: normalizeReplyItems(reply?.consumed || reply?.used_items || []),
+                    rewards: normalizeReplyItems([
+                        ...(Array.isArray(reply?.rewards) ? reply.rewards : []),
+                        ...(Array.isArray(reply?.items) ? reply.items : []),
+                        ...(Array.isArray(reply?.land_reward?.items) ? reply.land_reward.items : []),
+                    ]),
+                });
+            } catch (error: any) {
+                attempts.push(interactionFailure(String(info.name || `物品${itemId}`), landId, error, target));
+                const gatewayFailure = typeof GatewayError === 'function' && error instanceof GatewayError;
+                if (!gatewayFailure && !(error instanceof FriendInteractionBusinessError)) {
+                    for (const remainingLandId of landIds.slice(index + 1)) {
+                        attempts.push({
+                            landId: remainingLandId,
+                            ok: false,
+                            code: 'FRIEND_INTERACTION_BATCH_ABORTED',
+                            message: '前序请求被中断，本地未继续提交该地块',
+                            target: targetMap.get(remainingLandId) || null,
+                        });
+                    }
+                    break;
+                }
+            }
+        }
+    } finally {
+        await leaveFriendFarm(friendGidNumber);
+    }
+
+    const succeeded = attempts.filter((attempt: any) => attempt.ok);
+    const failed = attempts.filter((attempt: any) => !attempt.ok);
+    const ownerName = String(enterReply?.basic?.remark || enterReply?.basic?.name || `GID:${friendGid}`);
+    const itemName = String(info.name || `物品${itemId}`);
+    const refreshedInventory = await getFriendInteractionItems();
+    return {
+        hostGid: friendGid,
+        ownerName,
+        itemId: String(itemId),
+        itemName,
+        protocol: 'item-use',
+        requestedLandIds: landIds,
+        usedLandIds: succeeded.map((attempt: any) => attempt.landId),
+        failedLandIds: failed.map((attempt: any) => attempt.landId),
+        successCount: succeeded.length,
+        failureCount: failed.length,
+        results: attempts,
+        items: refreshedInventory.items,
+        message: failed.length > 0
+            ? `已在${ownerName}的农场按顺序使用 ${succeeded.length} 个${itemName}，跳过 ${failed.length} 块地`
+            : `已在${ownerName}的农场按顺序使用 ${succeeded.length} 个${itemName}`,
+    };
+}
+
+let mutationTail: Promise<void> = Promise.resolve();
+
+function serializeMutation<T>(operation: () => Promise<T>): Promise<T> {
+    const run = mutationTail.then(operation, operation);
+    mutationTail = run.then(() => undefined, () => undefined);
+    return run;
+}
+
+function useFriendInteractionItemBatch(friendGidInput: unknown, itemIdInput: unknown, landIdsInput: unknown): Promise<any> {
+    return serializeMutation(() => performFriendInteractionItemBatch(friendGidInput, itemIdInput, landIdsInput));
+}
+
+module.exports = {
+    MAX_BATCH_LANDS,
+    isFriendLandInteractionMetadata,
+    getFriendInteractionItems,
+    useFriendInteractionItemBatch,
+};

--- a/core/src/services/qixi-dew.ts
+++ b/core/src/services/qixi-dew.ts
@@ -1,0 +1,391 @@
+/** 七夕鹊羽灵露：候选地块读取与定向物品使用。 */
+
+export {};
+
+const LongModule = require('long');
+const { PHASE_NAMES, PlantPhase } = require('../config/config');
+const { getItemById, getItemImageById, getPlantById, getPlantName, getSeedImageBySeedId } = require('../config/gameConfig');
+const { sendMsgAsync, getUserState, GatewayError } = require('../utils/network');
+const { types } = require('../utils/proto');
+const { toNum } = require('../utils/utils');
+const { getAllLands } = require('./farm/api');
+const { buildLandMap, getCurrentPhase, getDisplayLandContext } = require('./farm/land-analysis');
+const { enterFriendFarm, leaveFriendFarm } = require('./friend/api');
+const { getBag, getBagItems } = require('./warehouse');
+
+const QIXI_DEW_ITEM_ID = 301103;
+const QIXI_DEW_USE_CONFIG_ID = 0;
+const MAX_QIXI_DEW_BATCH_LANDS = 48;
+const MAX_SIGNED_INT64 = 9223372036854775807n;
+
+class QixiDewBusinessError extends Error {
+    code: string;
+
+    constructor(code: string, message: string) {
+        super(message);
+        this.name = 'QixiDewBusinessError';
+        this.code = code;
+    }
+}
+
+function businessError(code: string, message: string): QixiDewBusinessError {
+    return new QixiDewBusinessError(code, message);
+}
+
+function int64String(value: any): string {
+    if (value == null) return '0';
+    if (LongModule.isLong(value)) return value.toString();
+    const text = String(value).trim();
+    return /^-?\d+$/.test(text) ? text : '0';
+}
+
+function positiveDecimal(value: unknown, code: string, fieldName: string): string {
+    const normalized = int64String(value);
+    if (!/^[1-9]\d*$/.test(normalized) || normalized.length > 19 || BigInt(normalized) > MAX_SIGNED_INT64) {
+        throw businessError(code, `${fieldName} 必须是 int64 范围内的正十进制整数`);
+    }
+    return normalized;
+}
+
+function normalizeLandIds(value: unknown): string[] {
+    const source = Array.isArray(value) ? value : [value];
+    const unique = new Set<string>();
+    for (const entry of source) {
+        unique.add(positiveDecimal(entry, 'INVALID_QIXI_DEW_LAND_IDS', 'landIds'));
+    }
+    if (unique.size === 0) {
+        throw businessError('INVALID_QIXI_DEW_LAND_IDS', '至少选择一块地');
+    }
+    if (unique.size > MAX_QIXI_DEW_BATCH_LANDS) {
+        throw businessError('INVALID_QIXI_DEW_LAND_IDS', `单次最多选择 ${MAX_QIXI_DEW_BATCH_LANDS} 块地`);
+    }
+    return [...unique].sort((left, right) => {
+        const leftId = BigInt(left);
+        const rightId = BigInt(right);
+        return leftId < rightId ? -1 : leftId > rightId ? 1 : 0;
+    });
+}
+
+function landTypeName(levelInput: unknown): string {
+    const level = toNum(levelInput);
+    if (level <= 1) return '普通土地';
+    return ({
+        2: '红土地',
+        3: '黑土地',
+        4: '金土地',
+        5: '紫金土地',
+    } as Record<number, string>)[level] || `等级 ${level} 土地`;
+}
+
+function currentUser() {
+    const state = getUserState() || {};
+    const gid = positiveDecimal(state.gid, 'QIXI_DEW_ACCOUNT_UNAVAILABLE', '当前账号 GID');
+    return {
+        gid,
+        name: String(state.remark || state.name || `GID:${gid}`),
+        avatarUrl: String(state.avatar_url || state.avatarUrl || ''),
+    };
+}
+
+function resolveHost(hostGidInput: unknown) {
+    const user = currentUser();
+    const input = String(hostGidInput ?? '').trim();
+    const gid = !input || input === '0'
+        ? user.gid
+        : positiveDecimal(input, 'INVALID_QIXI_DEW_HOST_GID', 'hostGid');
+    return { ...user, gid, isSelf: gid === user.gid };
+}
+
+function itemDto(item: any) {
+    const id = int64String(item?.id ?? item?.item_id);
+    const numericId = Number(id);
+    const metadata = Number.isSafeInteger(numericId) && numericId > 0 ? getItemById(numericId) : null;
+    return {
+        id,
+        count: int64String(item?.count),
+        uid: int64String(item?.uid),
+        name: metadata?.name || `物品${id}`,
+        image: metadata ? getItemImageById(numericId) : '',
+    };
+}
+
+function buildDewLandTargets(landsInput: any[], host: any): any[] {
+    const lands = Array.isArray(landsInput) ? landsInput : [];
+    const landsMap = buildLandMap(lands);
+    const seen = new Set<number>();
+    const targets: any[] = [];
+
+    for (const land of lands) {
+        if (!land?.unlocked) continue;
+        const context = getDisplayLandContext(land, landsMap);
+        if (context.occupiedByMaster) continue;
+        const sourceLand = context.sourceLand || land;
+        const landId = toNum(sourceLand?.id);
+        if (landId <= 0 || seen.has(landId)) continue;
+
+        const plant = sourceLand?.plant;
+        if (!plant || !Array.isArray(plant.phases) || plant.phases.length === 0) continue;
+        const currentPhase = getCurrentPhase(plant.phases, false, '');
+        const phaseCode = toNum(currentPhase?.phase);
+        if (phaseCode < PlantPhase.SEED || phaseCode > PlantPhase.MATURE || phaseCode === PlantPhase.DEAD) continue;
+
+        const plantId = toNum(plant.id);
+        const plantConfig = getPlantById(plantId);
+        const seedId = toNum(plantConfig?.seed_id);
+        const landLevel = toNum(sourceLand?.level ?? land?.level);
+        seen.add(landId);
+        targets.push({
+            id: String(landId),
+            landId: String(landId),
+            hostGid: String(host.gid),
+            ownerName: String(host.name || `GID:${host.gid}`),
+            isSelf: !!host.isSelf,
+            plantId: String(plantId),
+            plantName: getPlantName(plantId) || String(plant.name || '未知作物'),
+            seedId: String(seedId || 0),
+            seedImage: seedId > 0 ? getSeedImageBySeedId(seedId) : '',
+            landLevel,
+            landTypeName: landTypeName(landLevel),
+            phaseCode,
+            phaseName: PHASE_NAMES[phaseCode] || `阶段${phaseCode}`,
+            mature: phaseCode === PlantPhase.MATURE,
+            occupiedLandIds: (Array.isArray(context.occupiedLandIds) ? context.occupiedLandIds : [landId])
+                .map((id: any) => String(toNum(id)))
+                .filter((id: string) => id !== '0'),
+            activityMarker: int64String(plant?.field_36?.activity_id),
+        });
+    }
+
+    return targets.sort((left, right) => Number(left.landId) - Number(right.landId));
+}
+
+function friendHost(reply: any, requestedGid: string) {
+    const actualGid = int64String(reply?.basic?.gid);
+    if (actualGid !== '0' && actualGid !== requestedGid) {
+        throw businessError('QIXI_DEW_HOST_MISMATCH', '进入的好友农场与所选 GID 不一致');
+    }
+    return {
+        gid: requestedGid,
+        name: String(reply?.basic?.remark || reply?.basic?.name || `GID:${requestedGid}`),
+        avatarUrl: String(reply?.basic?.avatar_url || ''),
+        isSelf: false,
+    };
+}
+
+async function getQixiDewTargets(hostGidInput: unknown = '') {
+    const host = resolveHost(hostGidInput);
+    if (host.isSelf) {
+        const reply = await getAllLands();
+        const lands = buildDewLandTargets(reply?.lands || [], host);
+        return { host, lands, count: lands.length, serverValidationRequired: true };
+    }
+
+    const reply = await enterFriendFarm(Number(host.gid));
+    try {
+        const enteredHost = friendHost(reply, host.gid);
+        const lands = buildDewLandTargets(reply?.lands || [], enteredHost);
+        return { host: enteredHost, lands, count: lands.length, serverValidationRequired: true };
+    } finally {
+        await leaveFriendFarm(Number(host.gid));
+    }
+}
+
+function findDewStack(bagReply: any): any | null {
+    return getBagItems(bagReply).find((item: any) => (
+        int64String(item?.id ?? item?.item_id) === String(QIXI_DEW_ITEM_ID)
+        && BigInt(int64String(item?.count)) > 0n
+    )) || null;
+}
+
+async function sendDewUse(stack: any, hostGid: string, landId: string): Promise<any> {
+    const request = types.UseRequest.create({
+        item: {
+            id: QIXI_DEW_ITEM_ID,
+            count: 1,
+            uid: stack.uid,
+        },
+        target: {
+            host_gid: hostGid,
+            land_ids: [landId],
+            use_config_id: QIXI_DEW_USE_CONFIG_ID,
+        },
+    });
+    const body = Buffer.from(types.UseRequest.encode(request).finish());
+    const { body: replyBody } = await sendMsgAsync('gamepb.itempb.ItemService', 'Use', body);
+    return types.UseReply.decode(replyBody);
+}
+
+function dewAttemptFailure(landId: string, error: any, target: any = null) {
+    const code = String(error?.code || String(error?.message || '').match(/\bcode=(\d+)\b/)?.[1] || 'QIXI_DEW_USE_FAILED');
+    const knownMessages: Record<string, string> = {
+        '1001065': '该地块当前不符合灵露使用条件，可能是作物品级不足或状态已变化',
+        '1003008': '该农场当前已达到灵露使用限制',
+        QIXI_DEW_TARGET_UNAVAILABLE: '该地块已经没有可使用灵露的作物',
+    };
+    const serverMessage = String(error?.errorMessage || '').trim();
+    const businessMessage = error instanceof QixiDewBusinessError ? String(error.message || '') : '';
+    return {
+        landId,
+        ok: false,
+        code,
+        message: knownMessages[code] || businessMessage || serverMessage || '服务器未接受该地块的灵露使用请求',
+        target,
+        error,
+    };
+}
+
+async function useDewOnLands(stack: any, host: any, landsInput: any[], landIds: string[]) {
+    const targets = buildDewLandTargets(landsInput, host);
+    const targetsById = new Map(targets.map((target: any) => [target.landId, target]));
+    const attempts: any[] = [];
+
+    for (let index = 0; index < landIds.length; index += 1) {
+        const landId = landIds[index];
+        const target = targetsById.get(landId) || null;
+        if (!target) {
+            attempts.push(dewAttemptFailure(
+                landId,
+                businessError('QIXI_DEW_TARGET_UNAVAILABLE', '所选地块已无可使用灵露的作物'),
+            ));
+            continue;
+        }
+
+        try {
+            const reply = await sendDewUse(stack, host.gid, landId);
+            const directRewards = Array.isArray(reply?.items) ? reply.items : [];
+            const landRewards = Array.isArray(reply?.land_reward?.items) ? reply.land_reward.items : [];
+            attempts.push({
+                landId,
+                ok: true,
+                code: '',
+                message: `第 ${landId} 块地使用成功`,
+                target,
+                updatedLand: reply?.land || null,
+                rewardLandId: int64String(reply?.land_reward?.land_id),
+                usedItems: (Array.isArray(reply?.used_items) ? reply.used_items : []).map(itemDto),
+                rewards: [...directRewards, ...landRewards].map(itemDto),
+            });
+        } catch (error: any) {
+            attempts.push(dewAttemptFailure(landId, error, target));
+            const gatewayFailure = typeof GatewayError === 'function' && error instanceof GatewayError;
+            if (!gatewayFailure && !(error instanceof QixiDewBusinessError)) {
+                for (const remainingLandId of landIds.slice(index + 1)) {
+                    attempts.push({
+                        landId: remainingLandId,
+                        ok: false,
+                        code: 'QIXI_DEW_BATCH_ABORTED',
+                        message: '前序请求被中断，本地未继续提交该地块',
+                        target: targetsById.get(remainingLandId) || null,
+                    });
+                }
+                break;
+            }
+        }
+    }
+
+    return attempts;
+}
+
+async function performQixiDewBatch(hostGidInput: unknown, landIdsInput: unknown) {
+    const host = resolveHost(hostGidInput);
+    const landIds = normalizeLandIds(landIdsInput);
+    const activity = await require('./activity-center').getCurrentQixiActivity();
+    if (!activity?.active) {
+        throw businessError('QIXI_DEW_UNAVAILABLE', '鹊桥寄情活动未进行，灵露当前不可使用');
+    }
+
+    const bagReply = await getBag();
+    const dewStack = findDewStack(bagReply);
+    if (!dewStack) {
+        throw businessError('INSUFFICIENT_QIXI_DEW', '背包中没有可用的鹊羽灵露');
+    }
+    const available = BigInt(int64String(dewStack.count));
+    if (BigInt(landIds.length) > available) {
+        throw businessError(
+            'QIXI_DEW_SELECTION_EXCEEDS_BALANCE',
+            `已选择 ${landIds.length} 块地，但当前只有 ${available.toString()} 份鹊羽灵露`,
+        );
+    }
+
+    let activeHost = host;
+    let attempts: any[] = [];
+    if (host.isSelf) {
+        const landsReply = await getAllLands();
+        attempts = await useDewOnLands(dewStack, host, landsReply?.lands || [], landIds);
+    } else {
+        const enterReply = await enterFriendFarm(Number(host.gid));
+        try {
+            activeHost = friendHost(enterReply, host.gid);
+            // The whole ordered batch stays inside one Visit Enter/Leave session.
+            attempts = await useDewOnLands(dewStack, activeHost, enterReply?.lands || [], landIds);
+        } finally {
+            await leaveFriendFarm(Number(host.gid));
+        }
+    }
+
+    const publicResults = attempts.map(({ error: _error, ...attempt }) => attempt);
+    const succeeded = publicResults.filter((attempt: any) => attempt.ok);
+    const failed = publicResults.filter((attempt: any) => !attempt.ok);
+    const snapshot = await require('./activity-center').getActivityCenterSnapshot();
+    const owner = activeHost.isSelf ? '自己农场' : `${activeHost.name}的农场`;
+    const summary = failed.length > 0
+        ? `已在${owner}按顺序使用 ${succeeded.length} 份灵露，跳过 ${failed.length} 块地`
+        : `已在${owner}按顺序使用 ${succeeded.length} 份灵露`;
+    return {
+        activityKey: `${String(activity.activityId || activity.groupId || '')}:${String(activity.startTime || '')}`,
+        hostGid: activeHost.gid,
+        ownerName: activeHost.name,
+        requestedLandIds: landIds,
+        usedLandIds: succeeded.map((attempt: any) => attempt.landId),
+        failedLandIds: failed.map((attempt: any) => attempt.landId),
+        successCount: succeeded.length,
+        failureCount: failed.length,
+        results: publicResults,
+        usedItems: succeeded.flatMap((attempt: any) => attempt.usedItems || []),
+        rewards: succeeded.flatMap((attempt: any) => attempt.rewards || []),
+        message: summary,
+        snapshot,
+    };
+}
+
+let mutationTail: Promise<void> = Promise.resolve();
+
+function serializeMutation<T>(operation: () => Promise<T>): Promise<T> {
+    const run = mutationTail.then(operation, operation);
+    mutationTail = run.then(() => undefined, () => undefined);
+    return run;
+}
+
+async function useQixiDew(hostGidInput: unknown, landIdInput: unknown) {
+    return serializeMutation(async () => {
+        const landId = positiveDecimal(landIdInput, 'INVALID_QIXI_DEW_LAND_ID', 'landId');
+        const batch = await performQixiDewBatch(hostGidInput, [landId]);
+        const attempt = batch.results[0];
+        if (!attempt?.ok) {
+            throw businessError(String(attempt?.code || 'QIXI_DEW_USE_FAILED'), String(attempt?.message || '灵露使用失败'));
+        }
+        return {
+            hostGid: batch.hostGid,
+            landId,
+            target: attempt.target,
+            updatedLand: attempt.updatedLand,
+            rewardLandId: attempt.rewardLandId,
+            usedItems: attempt.usedItems,
+            rewards: attempt.rewards,
+            message: `已在${attempt.target.isSelf ? '自己农场' : `${attempt.target.ownerName}的农场`}第 ${landId} 块地使用 1 份鹊羽灵露`,
+            snapshot: batch.snapshot,
+        };
+    });
+}
+
+async function useQixiDewBatch(hostGidInput: unknown, landIdsInput: unknown) {
+    return serializeMutation(() => performQixiDewBatch(hostGidInput, landIdsInput));
+}
+
+module.exports = {
+    QIXI_DEW_ITEM_ID,
+    buildDewLandTargets,
+    getQixiDewTargets,
+    useQixiDew,
+    useQixiDewBatch,
+};

--- a/core/src/utils/proto.ts
+++ b/core/src/utils/proto.ts
@@ -112,6 +112,7 @@ async function loadProto(): Promise<void> {
     types.SellRequest = root.lookupType('gamepb.itempb.SellRequest');
     types.SellReply = root.lookupType('gamepb.itempb.SellReply');
     types.UseRequest = root.lookupType('gamepb.itempb.UseRequest');
+    types.UseTarget = root.lookupType('gamepb.itempb.UseTarget');
     types.UseReply = root.lookupType('gamepb.itempb.UseReply');
     types.BatchUseRequest = root.lookupType('gamepb.itempb.BatchUseRequest');
     types.BatchUseReply = root.lookupType('gamepb.itempb.BatchUseReply');

--- a/core/tests/activity-snapshot-serialization.test.js
+++ b/core/tests/activity-snapshot-serialization.test.js
@@ -92,6 +92,7 @@ test('activity snapshots are single-flight and serialize gateway reads', async (
     });
     require.cache[windowsPath] = loadedModule(windowsPath, {
         getActivityWindows: () => tracked('ActivityList', []),
+        getSellConditionContext: async () => ({ nowSec: 1, activityWindows: new Map(), activityWindowsLoaded: true }),
     });
     require.cache[registryPath] = loadedModule(registryPath, {
         buildActivityGameplayBindings: () => ({}),
@@ -109,6 +110,7 @@ test('activity snapshots are single-flight and serialize gateway reads', async (
     require.cache[gameConfigPath] = loadedModule(gameConfigPath, {
         getItemById: () => null,
         getItemImageById: () => '',
+        getEffectiveSellInfo: () => ({ sellable: false, status: 'unavailable', condition: null, sells: [] }),
     });
     require.cache[utilsPath] = loadedModule(utilsPath, { getServerTimeSec: () => 1 });
 

--- a/core/tests/friend-interaction-items.test.js
+++ b/core/tests/friend-interaction-items.test.js
@@ -1,0 +1,244 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+function loadedModule(filename, exports) {
+    return { id: filename, filename, loaded: true, exports };
+}
+
+function installMocks(options = {}) {
+    const servicePath = require.resolve('../dist/services/friend-interaction-items');
+    const configPath = require.resolve('../dist/config/config');
+    const gameConfigPath = require.resolve('../dist/config/gameConfig');
+    const networkPath = require.resolve('../dist/utils/network');
+    const protoPath = require.resolve('../dist/utils/proto');
+    const utilsPath = require.resolve('../dist/utils/utils');
+    const activityWindowsPath = require.resolve('../dist/services/activity-windows');
+    const landAnalysisPath = require.resolve('../dist/services/farm/land-analysis');
+    const friendApiPath = require.resolve('../dist/services/friend/api');
+    const warehousePath = require.resolve('../dist/services/warehouse');
+    const mockedPaths = [
+        configPath,
+        gameConfigPath,
+        networkPath,
+        protoPath,
+        utilsPath,
+        activityWindowsPath,
+        landAnalysisPath,
+        friendApiPath,
+        warehousePath,
+    ];
+    const previous = new Map(mockedPaths.map(path => [path, require.cache[path]]));
+    const calls = [];
+    const encodedUseRequests = [];
+
+    class MockGatewayError extends Error {
+        constructor(code, errorMessage) {
+            super(`code=${code} ${errorMessage}`);
+            this.code = code;
+            this.errorMessage = errorMessage;
+        }
+    }
+
+    const metadata = new Map((options.metadata || []).map(item => [Number(item.id), item]));
+    const bagItems = options.bagItems || [];
+    const lands = options.lands || [
+        { id: 1, unlocked: true, plant: { id: 9001, phases: [{ phase: 2 }] } },
+        { id: 2, unlocked: true, plant: { id: 9002, phases: [{ phase: 2 }] } },
+        { id: 3, unlocked: true, plant: { id: 9003, phases: [{ phase: 2 }] } },
+    ];
+
+    require.cache[configPath] = loadedModule(configPath, {
+        PlantPhase: { DEAD: 7 },
+    });
+    require.cache[gameConfigPath] = loadedModule(gameConfigPath, {
+        getItemById: id => metadata.get(Number(id)),
+        getItemImageById: id => `/item/${id}.png`,
+    });
+    require.cache[networkPath] = loadedModule(networkPath, {
+        GatewayError: MockGatewayError,
+        sendMsgAsync: async (serviceName, methodName) => {
+            calls.push(`ItemUse:${serviceName}.${methodName}`);
+            const request = encodedUseRequests.at(-1);
+            if (typeof options.onItemUse === 'function') await options.onItemUse(request, MockGatewayError);
+            return { body: Buffer.alloc(0) };
+        },
+    });
+    require.cache[protoPath] = loadedModule(protoPath, {
+        types: {
+            UseRequest: {
+                create: value => value,
+                encode: (value) => {
+                    encodedUseRequests.push(value);
+                    return { finish: () => Buffer.alloc(0) };
+                },
+            },
+            UseReply: {
+                decode: () => ({ used_items: [], items: [] }),
+            },
+        },
+    });
+    require.cache[utilsPath] = loadedModule(utilsPath, {
+        toNum: value => Number(value?.toString?.() ?? value) || 0,
+    });
+    require.cache[activityWindowsPath] = loadedModule(activityWindowsPath, {
+        getSellConditionContext: async () => options.sellContext || {
+            nowSec: 200,
+            activityWindows: new Map(),
+            activityWindowsLoaded: true,
+        },
+    });
+    require.cache[landAnalysisPath] = loadedModule(landAnalysisPath, {
+        buildLandMap: values => new Map(values.map(land => [Number(land.id), land])),
+        getCurrentPhase: phases => phases[0] || null,
+        getDisplayLandContext: land => ({
+            sourceLand: land,
+            occupiedByMaster: false,
+            occupiedLandIds: [Number(land.id)],
+        }),
+    });
+    require.cache[friendApiPath] = loadedModule(friendApiPath, {
+        enterFriendFarm: async (gid) => {
+            calls.push('Enter');
+            return { basic: { gid, name: '好友甲' }, lands };
+        },
+        leaveFriendFarm: async () => calls.push('Leave'),
+    });
+    require.cache[warehousePath] = loadedModule(warehousePath, {
+        getBag: async () => ({ item_bag: { items: bagItems } }),
+        getBagItems: reply => reply?.item_bag?.items || [],
+    });
+
+    delete require.cache[servicePath];
+    const service = require('../dist/services/friend-interaction-items');
+    return {
+        service,
+        calls,
+        getEncodedUseRequests: () => encodedUseRequests,
+        restore() {
+            delete require.cache[servicePath];
+            for (const path of mockedPaths) {
+                const cached = previous.get(path);
+                if (cached) require.cache[path] = cached;
+                else delete require.cache[path];
+            }
+        },
+    };
+}
+
+const specialItem = (id, name, extra = {}) => ({
+    id,
+    type: 23,
+    name,
+    interaction_type: 'additemuseItem',
+    can_use: 1,
+    desc: '可在好友农场的作物上使用。',
+    ...extra,
+});
+
+test('特殊互动库存保留满足出售条件的道具，并单独标记供使用前提示', { concurrency: false }, async () => {
+    const mock = installMocks({
+        metadata: [
+            specialItem(301101, '黄金虫'),
+            specialItem(301102, '足球', { activity_id: 2026071501 }),
+            specialItem(301103, '鹊羽灵露', { sell_cond: '活动结束后:2026081801' }),
+            specialItem(5003, '闪电变异瓶', { desc: '使自己的未成熟作物发生变异。' }),
+            specialItem(5004, '霹雳引雷瓶', { sell_cond: '道具过期后:expire_time' }),
+        ],
+        bagItems: [
+            { id: 301101, count: 2, uid: 11 },
+            { id: 301102, count: 3, uid: 12 },
+            { id: 301103, count: 4, uid: 13 },
+            { id: 5003, count: 5, uid: 14 },
+            { id: 5004, count: 6, uid: 15, expire_time: 150 },
+        ],
+        sellContext: {
+            nowSec: 200,
+            activityWindows: new Map([
+                ['2026081801', { id: '2026081801', beginTime: 50, endTime: 100 }],
+            ]),
+            activityWindowsLoaded: true,
+        },
+    });
+
+    try {
+        const result = await mock.service.getFriendInteractionItems();
+        assert.deepEqual(result.items.map(item => item.itemId), ['5004', '301103', '301102', '301101']);
+        assert.equal(result.items.find(item => item.itemId === '5004').count, 6);
+        assert.equal(result.items.find(item => item.itemId === '5004').saleConditionSatisfiedCount, 6);
+        assert.equal(result.items.find(item => item.itemId === '301103').count, 4);
+        assert.equal(result.items.find(item => item.itemId === '301103').saleConditionSatisfiedCount, 4);
+        assert.equal(result.items.find(item => item.itemId === '301102').count, 3);
+        assert.equal(result.items.find(item => item.itemId === '301102').activityId, '2026071501');
+        assert.equal(result.items.find(item => item.itemId === '301101').saleConditionSatisfiedCount, 0);
+        assert.equal(result.items.find(item => item.itemId === '301101').protocol, 'item-use');
+    } finally {
+        mock.restore();
+    }
+});
+
+test('黄金虫在一次好友会话内按地块编号顺序使用，服务端单块拒绝后继续', { concurrency: false }, async () => {
+    const mock = installMocks({
+        metadata: [specialItem(301101, '黄金虫')],
+        bagItems: [{ id: 301101, count: 3, uid: 11 }],
+        onItemUse: (request, MockGatewayError) => {
+            if (Number(request.target.land_ids[0]) === 2) {
+                throw new MockGatewayError(1003008, '达到使用限制');
+            }
+        },
+    });
+
+    try {
+        const result = await mock.service.useFriendInteractionItemBatch('200', '301101', ['3', '1', '2', '2']);
+        assert.deepEqual(mock.calls.filter(call => call === 'Enter' || call === 'Leave' || call.startsWith('ItemUse:')), [
+            'Enter',
+            'ItemUse:gamepb.itempb.ItemService.Use',
+            'ItemUse:gamepb.itempb.ItemService.Use',
+            'ItemUse:gamepb.itempb.ItemService.Use',
+            'Leave',
+        ]);
+        assert.deepEqual(mock.getEncodedUseRequests().map(request => request.target.land_ids), [['1'], ['2'], ['3']]);
+        assert.equal(result.protocol, 'item-use');
+        assert.deepEqual(result.requestedLandIds, ['1', '2', '3']);
+        assert.deepEqual(result.usedLandIds, ['1', '3']);
+        assert.deepEqual(result.failedLandIds, ['2']);
+        assert.match(result.results[1].message, /达到.*使用限制/);
+    } finally {
+        mock.restore();
+    }
+});
+
+test('灵露在售卖条件已满足时仍提交 ItemService.Use，由服务端判断是否可用', { concurrency: false }, async () => {
+    const mock = installMocks({
+        metadata: [specialItem(301103, '鹊羽灵露', { sell_cond: '活动结束后:2026081801' })],
+        bagItems: [{ id: 301103, count: 1, uid: 77 }],
+        sellContext: {
+            nowSec: 200,
+            activityWindows: new Map([
+                ['2026081801', { id: '2026081801', beginTime: 50, endTime: 100 }],
+            ]),
+            activityWindowsLoaded: true,
+        },
+    });
+
+    try {
+        const inventory = await mock.service.getFriendInteractionItems();
+        assert.equal(inventory.items[0].count, 1);
+        assert.equal(inventory.items[0].saleConditionSatisfiedCount, 1);
+
+        const result = await mock.service.useFriendInteractionItemBatch('200', '301103', ['3']);
+        const [request] = mock.getEncodedUseRequests();
+        assert.equal(result.protocol, 'item-use');
+        assert.equal(request.item.id, 301103);
+        assert.equal(request.item.uid, 77);
+        assert.deepEqual(request.target, {
+            host_gid: '200',
+            land_ids: ['3'],
+            use_config_id: 0,
+        });
+        assert.equal(mock.calls.some(call => call.startsWith('PlantSocial:')), false);
+        assert.equal(mock.calls.filter(call => call === 'Enter').length, 1);
+        assert.equal(mock.calls.filter(call => call === 'Leave').length, 1);
+    } finally {
+        mock.restore();
+    }
+});

--- a/core/tests/protocol-capture.test.js
+++ b/core/tests/protocol-capture.test.js
@@ -186,6 +186,31 @@ test('bag, item display, task and season additions use the captured wire types',
     assert.equal(number(pass.field_12), 8);
 });
 
+test('land unlock and upgrade conditions match captured field meanings', () => {
+    const unlock = type('gamepb.plantpb.LandUnlockCondition').decode(hex('08061005188827'));
+    assert.equal(number(unlock.preceding_land_id), 6);
+    assert.equal(number(unlock.need_level), 5);
+    assert.equal(number(unlock.need_gold), 5000);
+
+    const upgrade = type('gamepb.plantpb.LandUpgradeCondition').decode(hex(
+        '08011093011a0908e90710808f85cd011a0608ed0710c879',
+    ));
+    assert.equal(number(upgrade.condition_type), 1);
+    assert.equal(number(upgrade.condition_value), 147);
+    assert.deepEqual(upgrade.required_items.map(item => ({
+        id: number(item.id),
+        count: number(item.count),
+    })), [
+        { id: 1001, count: 430000000 },
+        { id: 1005, count: 15560 },
+    ]);
+
+    const jointPlantMaster = type('gamepb.plantpb.LandInfo').decode(hex('080572030106027802'));
+    assert.equal(number(jointPlantMaster.id), 5);
+    assert.deepEqual(jointPlantMaster.slave_land_ids.map(number), [1, 6, 2]);
+    assert.equal(number(jointPlantMaster.land_size), 2);
+});
+
 test('Qixi bridge and gifting messages match the captured activity frames', () => {
     const bridge = type('gamepb.activitypb.QixiBridgeConfig').decode(hex(
         '0a0508810810010a0508ea071001121a08011205088008101e1a0508810810051a0608cd970610012002'
@@ -199,16 +224,19 @@ test('Qixi bridge and gifting messages match the captured activity frames', () =
     const gift = type('gamepb.activitypb.QixiGiftProgress').decode(hex(
         '0801100c183222120a0508810810011205088208100118012001',
     ));
-    assert.equal(number(gift.sent_count), 1);
-    assert.equal(number(gift.field_2), 12);
-    assert.equal(number(gift.field_3), 50);
-    assert.equal(number(gift.exchange.sent_item.item_id), 1025);
+    assert.equal(number(gift.total_send_count), 1);
+    assert.equal(number(gift.total_send_limit), 12);
+    assert.equal(number(gift.total_receive_limit), 50);
+    assert.equal(number(gift.gifts[0].cost_items[0].item_id), 1025);
+    assert.equal(number(gift.gifts[0].receive_items[0].item_id), 1026);
+    assert.equal(number(gift.gifts[0].gift_type), 1);
+    assert.equal(number(gift.gifts[0].content), 1);
 
     const giftRequestType = type('gamepb.activitypb.GiftQixiSachetRequest');
     const giftRequest = giftRequestType.create({
         activity_id: '2026081802',
         operate_type: 26,
-        params: { friend_gid: '1142601927', count: 15 },
+        params: { target_gid: '1142601927', msg_text_id: 15 },
     });
     assert.equal(
         Buffer.from(giftRequestType.encode(giftRequest).finish()).toString('hex'),
@@ -219,7 +247,7 @@ test('Qixi bridge and gifting messages match the captured activity frames', () =
     const claimRequest = claimRequestType.create({
         activity_id: '2026081801',
         operate_type: 25,
-        params: { claim_mode: 0 },
+        params: { step: 0 },
     });
     assert.equal(
         Buffer.from(claimRequestType.encode(claimRequest).finish()).toString('hex'),
@@ -230,6 +258,65 @@ test('Qixi bridge and gifting messages match the captured activity frames', () =
         '0a010112130881081005188092b8c398feffffff0130962712160883f1041004188092b8c398feffffff0130ea263801'
         + '121108ea0710c801188092b8c398feffffff01',
     ));
-    assert.deepEqual(rewardResult.claimed_stages.map(number), [1]);
-    assert.deepEqual(rewardResult.rewards.map(item => number(item.id)), [1025, 80003, 1002]);
+    assert.deepEqual(rewardResult.unlocked_steps.map(number), [1]);
+    assert.deepEqual(rewardResult.awards.map(item => number(item.id)), [1025, 80003, 1002]);
+});
+
+test('Qixi dew targets only the captured 2x2 master land', () => {
+    const requestType = type('gamepb.itempb.UseRequest');
+    const capturedRequest = '0a0908afb012100130a0641209089082b7e103120105';
+    const decoded = requestType.decode(hex(capturedRequest));
+
+    assert.equal(number(decoded.item.id), 301103);
+    assert.equal(number(decoded.item.count), 1);
+    assert.equal(number(decoded.item.uid), 12832);
+    assert.equal(number(decoded.target.host_gid), 1009631504);
+    assert.deepEqual(decoded.target.land_ids.map(number), [5]);
+    assert.equal(number(decoded.target.use_config_id), 0);
+    assert.equal(Buffer.from(requestType.encode(decoded).finish()).toString('hex'), capturedRequest);
+
+    const reply = type('gamepb.itempb.UseReply').decode(hex(
+        '0a0908afb012100130816322bc0108051001180520054a1008b0ea0110d00f18c41320e05d28a01f'
+        + '529c0108c4ab3e1206e6a2a7e6a1902216080210cca891d406180c520a08cca891d406100d3003'
+        + '220a080210ccde91d4061814220a080610cc9492d4061813280150a4c30258f80e6a010078808e02'
+        + '8001018801019001f80ea201010db0018632d001a4c302d801f80e92020a08e90710c20318c4ab3e'
+        + 'a2020d08fe071031183120fcd48dc607a8028f01c2020408091001ca020a08cca891d406100d3003'
+        + '8001052a09080512050880081001',
+    ));
+    assert.equal(number(reply.land.id), 5);
+    assert.equal(reply.land.plant.name, '梧桐');
+    assert.equal(number(reply.land_reward.land_id), 5);
+    assert.deepEqual(reply.land_reward.items.map(item => number(item.id)), [1024]);
+    assert.deepEqual(reply.land_reward.items.map(item => number(item.count)), [1]);
+});
+
+test('football and golden insect use the captured generic item target protocol', () => {
+    const requestType = type('gamepb.itempb.UseRequest');
+    const captures = [
+        {
+            hex: '0a0908aeb012100130f452120908db93dcdd03120106',
+            itemId: 301102,
+            uid: 10612,
+            hostGid: 1001851355,
+            landId: 6,
+        },
+        {
+            hex: '0a0908adb012100130ba3d120908db93dcdd03120114',
+            itemId: 301101,
+            uid: 7866,
+            hostGid: 1001851355,
+            landId: 20,
+        },
+    ];
+
+    for (const capture of captures) {
+        const decoded = requestType.decode(hex(capture.hex));
+        assert.equal(number(decoded.item.id), capture.itemId);
+        assert.equal(number(decoded.item.count), 1);
+        assert.equal(number(decoded.item.uid), capture.uid);
+        assert.equal(number(decoded.target.host_gid), capture.hostGid);
+        assert.deepEqual(decoded.target.land_ids.map(number), [capture.landId]);
+        assert.equal(number(decoded.target.use_config_id), 0);
+        assert.equal(Buffer.from(requestType.encode(decoded).finish()).toString('hex'), capture.hex);
+    }
 });

--- a/core/tests/qixi-dew-lifecycle.test.js
+++ b/core/tests/qixi-dew-lifecycle.test.js
@@ -1,0 +1,29 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const { getEffectiveSellInfo, getItemById } = require('../dist/config/gameConfig');
+
+test('鹊羽灵露仅在服务端活动结束条件满足后开放手动出售', () => {
+    const dew = getItemById(301103);
+    assert.equal(dew.name, '鹊羽灵露');
+    assert.equal(dew.sell_cond, '活动结束后:2026081801');
+
+    const activeWindows = new Map([
+        ['2026081801', { id: '2026081801', beginTime: 100, endTime: 300 }],
+    ]);
+    const duringEvent = getEffectiveSellInfo(dew, {
+        nowSec: 200,
+        activityWindows: activeWindows,
+        activityWindowsLoaded: true,
+    });
+    assert.equal(duringEvent.sellable, false);
+    assert.equal(duringEvent.status, 'conditional');
+
+    const afterEvent = getEffectiveSellInfo(dew, {
+        nowSec: 301,
+        activityWindows: activeWindows,
+        activityWindowsLoaded: true,
+    });
+    assert.equal(afterEvent.sellable, true);
+    assert.equal(afterEvent.status, 'available');
+    assert.deepEqual(afterEvent.sells, [{ currencyId: 1001, price: 100 }]);
+});

--- a/core/tests/qixi-dew.test.js
+++ b/core/tests/qixi-dew.test.js
@@ -1,0 +1,175 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+function loadedModule(filename, exports) {
+    return { id: filename, filename, loaded: true, exports };
+}
+
+test('鹊羽灵露在好友访问会话内定向使用，并保留服务器最终资格校验', async () => {
+    const dewPath = require.resolve('../dist/services/qixi-dew');
+    const configPath = require.resolve('../dist/config/config');
+    const gameConfigPath = require.resolve('../dist/config/gameConfig');
+    const networkPath = require.resolve('../dist/utils/network');
+    const protoPath = require.resolve('../dist/utils/proto');
+    const utilsPath = require.resolve('../dist/utils/utils');
+    const farmApiPath = require.resolve('../dist/services/farm/api');
+    const landAnalysisPath = require.resolve('../dist/services/farm/land-analysis');
+    const friendApiPath = require.resolve('../dist/services/friend/api');
+    const warehousePath = require.resolve('../dist/services/warehouse');
+    const activityPath = require.resolve('../dist/services/activity-center');
+    const mockedPaths = [
+        configPath,
+        gameConfigPath,
+        networkPath,
+        protoPath,
+        utilsPath,
+        farmApiPath,
+        landAnalysisPath,
+        friendApiPath,
+        warehousePath,
+        activityPath,
+    ];
+    const previous = new Map(mockedPaths.map(path => [path, require.cache[path]]));
+    const calls = [];
+    let encodedRequest = null;
+    const encodedRequests = [];
+    let rejectedLandId = '';
+    class MockGatewayError extends Error {
+        constructor(code, errorMessage) {
+            super(`code=${code} ${errorMessage}`);
+            this.code = code;
+            this.errorMessage = errorMessage;
+        }
+    }
+    const plantedLands = [1, 2, 3].map(id => ({
+        id,
+        unlocked: true,
+        plant: { id: 9000 + id, name: `测试作物${id}`, phases: [{ phase: 2 }] },
+    }));
+
+    require.cache[configPath] = loadedModule(configPath, {
+        PHASE_NAMES: { 2: '发芽', 6: '成熟', 7: '枯死' },
+        PlantPhase: { UNKNOWN: 0, SEED: 1, MATURE: 6, DEAD: 7 },
+    });
+    require.cache[gameConfigPath] = loadedModule(gameConfigPath, {
+        getItemById: id => ({ id, name: id === 301103 ? '鹊羽灵露' : `物品${id}` }),
+        getItemImageById: id => `/item/${id}.png`,
+        getPlantById: () => ({ seed_id: 5001 }),
+        getPlantName: () => '测试作物',
+        getSeedImageBySeedId: id => `/seed/${id}.png`,
+    });
+    require.cache[networkPath] = loadedModule(networkPath, {
+        getUserState: () => ({ gid: 100, name: '自己' }),
+        GatewayError: MockGatewayError,
+        sendMsgAsync: async () => {
+            calls.push('Use');
+            const landId = String(encodedRequest?.target?.land_ids?.[0] || '');
+            if (landId && landId === rejectedLandId)
+                throw new MockGatewayError(1001065, '地块不符合使用条件');
+            return { body: Buffer.alloc(0) };
+        },
+    });
+    require.cache[protoPath] = loadedModule(protoPath, {
+        types: {
+            UseRequest: {
+                create: value => value,
+                encode: (value) => {
+                    encodedRequest = value;
+                    encodedRequests.push(value);
+                    return { finish: () => Buffer.alloc(0) };
+                },
+            },
+            UseReply: {
+                decode: () => ({
+                    used_items: [{ id: 301103, count: 1, uid: 77 }],
+                    land: { id: 3 },
+                    land_reward: {
+                        land_id: 3,
+                        items: [{ id: 1024, count: 1 }],
+                    },
+                }),
+            },
+        },
+    });
+    require.cache[utilsPath] = loadedModule(utilsPath, {
+        toNum: value => Number(value?.toString?.() ?? value) || 0,
+    });
+    require.cache[farmApiPath] = loadedModule(farmApiPath, {
+        getAllLands: async () => ({ lands: plantedLands }),
+    });
+    require.cache[landAnalysisPath] = loadedModule(landAnalysisPath, {
+        buildLandMap: lands => new Map(lands.map(land => [Number(land.id), land])),
+        getCurrentPhase: phases => phases[0] || null,
+        getDisplayLandContext: land => ({
+            sourceLand: land,
+            occupiedByMaster: false,
+            masterLandId: Number(land.id),
+            occupiedLandIds: [Number(land.id)],
+        }),
+    });
+    require.cache[friendApiPath] = loadedModule(friendApiPath, {
+        enterFriendFarm: async (gid) => {
+            calls.push('Enter');
+            return { basic: { gid, name: '好友甲' }, lands: plantedLands };
+        },
+        leaveFriendFarm: async () => calls.push('Leave'),
+    });
+    require.cache[warehousePath] = loadedModule(warehousePath, {
+        getBag: async () => {
+            calls.push('Bag');
+            return { item_bag: { items: [{ id: 301103, count: 5, uid: 77 }] } };
+        },
+        getBagItems: reply => reply?.item_bag?.items || [],
+    });
+    require.cache[activityPath] = loadedModule(activityPath, {
+        getCurrentQixiActivity: async () => {
+            calls.push('Activity');
+            return { active: true };
+        },
+        getActivityCenterSnapshot: async () => {
+            calls.push('Snapshot');
+            return { qixi: {} };
+        },
+    });
+
+    delete require.cache[dewPath];
+    try {
+        const dew = require('../dist/services/qixi-dew');
+        const result = await dew.useQixiDew('200', '3');
+
+        assert.deepEqual(calls, ['Activity', 'Bag', 'Enter', 'Use', 'Leave', 'Snapshot']);
+        assert.equal(encodedRequest.item.id, 301103);
+        assert.equal(encodedRequest.item.count, 1);
+        assert.equal(encodedRequest.item.uid, 77);
+        assert.deepEqual(encodedRequest.target, {
+            host_gid: '200',
+            land_ids: ['3'],
+            use_config_id: 0,
+        });
+        assert.equal(result.target.plantName, '测试作物');
+        assert.equal(result.updatedLand.id, 3);
+        assert.equal(result.rewardLandId, '3');
+        assert.equal(result.rewards[0].id, '1024');
+
+        calls.length = 0;
+        encodedRequests.length = 0;
+        rejectedLandId = '2';
+        const batch = await dew.useQixiDewBatch('200', ['3', '1', '2', '2']);
+
+        assert.deepEqual(calls, ['Activity', 'Bag', 'Enter', 'Use', 'Use', 'Use', 'Leave', 'Snapshot']);
+        assert.deepEqual(encodedRequests.map(request => request.target.land_ids[0]), ['1', '2', '3']);
+        assert.deepEqual(batch.requestedLandIds, ['1', '2', '3']);
+        assert.deepEqual(batch.usedLandIds, ['1', '3']);
+        assert.deepEqual(batch.failedLandIds, ['2']);
+        assert.equal(batch.successCount, 2);
+        assert.equal(batch.failureCount, 1);
+        assert.match(batch.results[1].message, /品级不足|状态已变化/);
+    } finally {
+        delete require.cache[dewPath];
+        for (const path of mockedPaths) {
+            const cached = previous.get(path);
+            if (cached) require.cache[path] = cached;
+            else delete require.cache[path];
+        }
+    }
+});

--- a/tools/decode-latest-protocols.js
+++ b/tools/decode-latest-protocols.js
@@ -11,8 +11,10 @@ const protobuf = coreRequire('protobufjs');
 const cryptoWasm = require('../core/src/utils/crypto-wasm.ts');
 
 const captureDir = path.resolve(process.argv[2] || 'C:/Users/liyp/Downloads/协议');
-const methodFilter = String(process.argv[3] || '');
-const shapeOnly = process.argv.includes('--shape');
+const options = process.argv.slice(3);
+const methodFilter = String(options.find(value => !value.startsWith('--')) || '');
+const shapeOnly = options.includes('--shape');
+const includeAllMethods = options.includes('--all');
 const protoDir = path.resolve(__dirname, '../core/src/proto');
 const protoFiles = fs.readdirSync(protoDir)
     .filter((name) => name.endsWith('.proto'))
@@ -46,6 +48,10 @@ const selected = new Set([
     'gamepb.itempb.ItemService.Bag',
     'gamepb.itempb.ItemService.Use',
     'gamepb.itempb.ItemService.BatchUse',
+    'gamepb.visitpb.VisitService.Enter',
+    'gamepb.visitpb.VisitService.Leave',
+    'gamepb.plantpb.PlantService.AllLands',
+    'gamepb.plantpb.PlantService.Plant',
     'gamepb.taskpb.TaskService.TaskInfo',
     'gamepb.taskpb.TaskService.ClaimTaskReward',
     'gamepb.seasonpb.SeasonService.GetSeasonInfo',
@@ -151,6 +157,10 @@ function knownType(root, service, method, messageType) {
         'gamepb.itempb.ItemService.Bag': request ? 'gamepb.itempb.BagRequest' : 'gamepb.itempb.BagReply',
         'gamepb.itempb.ItemService.Use': request ? 'gamepb.itempb.UseRequest' : 'gamepb.itempb.UseReply',
         'gamepb.itempb.ItemService.BatchUse': request ? 'gamepb.itempb.BatchUseRequest' : 'gamepb.itempb.BatchUseReply',
+        'gamepb.visitpb.VisitService.Enter': request ? 'gamepb.visitpb.EnterRequest' : 'gamepb.visitpb.EnterReply',
+        'gamepb.visitpb.VisitService.Leave': request ? 'gamepb.visitpb.LeaveRequest' : 'gamepb.visitpb.LeaveReply',
+        'gamepb.plantpb.PlantService.AllLands': request ? 'gamepb.plantpb.AllLandsRequest' : 'gamepb.plantpb.AllLandsReply',
+        'gamepb.plantpb.PlantService.Plant': request ? 'gamepb.plantpb.PlantRequest' : 'gamepb.plantpb.PlantReply',
         'gamepb.taskpb.TaskService.TaskInfo': request ? 'gamepb.taskpb.TaskInfoRequest' : 'gamepb.taskpb.TaskInfoReply',
         'gamepb.taskpb.TaskService.ClaimTaskReward': request ? 'gamepb.taskpb.ClaimTaskRewardRequest' : 'gamepb.taskpb.ClaimTaskRewardReply',
         'gamepb.seasonpb.SeasonService.GetSeasonInfo': request ? 'gamepb.seasonpb.GetSeasonInfoRequest' : 'gamepb.seasonpb.GetSeasonInfoReply',
@@ -191,7 +201,7 @@ async function main() {
         }
         const service = String(meta.service_name || '');
         const method = String(meta.method_name || '');
-        if (!selected.has(`${service}.${method}`)) continue;
+        if (!includeAllMethods && !selected.has(`${service}.${method}`)) continue;
         if (methodFilter && method !== methodFilter) continue;
 
         let body = Buffer.from(message.body || []);

--- a/web/src/components/FarmPanel.vue
+++ b/web/src/components/FarmPanel.vue
@@ -7,14 +7,11 @@ import ConfirmModal from '@/components/ConfirmModal.vue'
 import LandCard from '@/components/LandCard.vue'
 import { useAccountStore } from '@/stores/account'
 import { useFarmStore } from '@/stores/farm'
-import { useStatusStore } from '@/stores/status'
 
 const farmStore = useFarmStore()
 const accountStore = useAccountStore()
-const statusStore = useStatusStore()
-const { lands, summary, loading } = storeToRefs(farmStore)
+const { lands, summary, loading, loaded, error } = storeToRefs(farmStore)
 const { currentAccountId, currentAccount } = storeToRefs(accountStore)
-const { status, loading: statusLoading, realtimeConnected } = storeToRefs(statusStore)
 
 const operating = ref(false)
 const confirmVisible = ref(false)
@@ -66,24 +63,23 @@ const operations = [
 ] as const
 
 async function refresh() {
-  if (currentAccountId.value) {
-    const acc = currentAccount.value
-    if (!acc)
-      return
-
-    if (!realtimeConnected.value) {
-      await statusStore.fetchStatus(currentAccountId.value)
-    }
-
-    if (acc.running && status.value?.connection?.connected) {
-      farmStore.fetchLands(currentAccountId.value)
-    }
-  }
+  const accountId = currentAccountId.value
+  if (!accountId || !currentAccount.value?.running)
+    return
+  await farmStore.fetchLands(accountId)
 }
 
 watch(currentAccountId, () => {
-  refresh()
+  farmStore.resetLandState()
 })
+
+watch([currentAccountId, () => currentAccount.value?.running], () => {
+  if (!currentAccount.value?.running) {
+    farmStore.resetLandState()
+    return
+  }
+  void refresh()
+}, { immediate: true })
 
 const { pause, resume } = useIntervalFn(() => {
   for (const land of lands.value || []) {
@@ -95,7 +91,6 @@ const { pause, resume } = useIntervalFn(() => {
 const { pause: pauseRefresh, resume: resumeRefresh } = useIntervalFn(refresh, 60000)
 
 onMounted(() => {
-  refresh()
   resume()
   resumeRefresh()
 })
@@ -119,7 +114,7 @@ onUnmounted(() => {
             v-for="op in operations"
             :key="op.type"
             :type="op.buttonType"
-            :disabled="operating"
+            :disabled="operating || !currentAccount?.running"
             @click="handleOperate(op.type)"
           >
             <span :class="op.icon" />
@@ -132,25 +127,25 @@ onUnmounted(() => {
       <div class="flex flex-wrap gap-x-5 gap-y-2 border-b border-gray-100 px-5 py-3 text-sm dark:border-gray-700">
         <div class="flex items-center gap-1.5 text-amber-700 dark:text-amber-300">
           <div class="i-carbon-clean" />
-          <span class="font-body font-semibold">可收: {{ summary?.harvestable || 0 }}</span>
+          <span class="font-body font-semibold">可收: {{ loaded && !error ? (summary?.harvestable || 0) : '--' }}</span>
         </div>
         <div class="flex items-center gap-1.5 text-green-700 dark:text-green-300">
           <div class="i-carbon-sprout" />
-          <span class="font-body font-semibold">生长: {{ summary?.growing || 0 }}</span>
+          <span class="font-body font-semibold">生长: {{ loaded && !error ? (summary?.growing || 0) : '--' }}</span>
         </div>
         <div class="flex items-center gap-1.5 text-gray-600 dark:text-gray-300">
           <div class="i-carbon-checkbox" />
-          <span class="font-body font-semibold">空闲: {{ summary?.empty || 0 }}</span>
+          <span class="font-body font-semibold">空闲: {{ loaded && !error ? (summary?.empty || 0) : '--' }}</span>
         </div>
         <div class="flex items-center gap-1.5 text-red-700 dark:text-red-300">
           <div class="i-carbon-warning" />
-          <span class="font-body font-semibold">枯萎: {{ summary?.dead || 0 }}</span>
+          <span class="font-body font-semibold">枯萎: {{ loaded && !error ? (summary?.dead || 0) : '--' }}</span>
         </div>
       </div>
 
       <!-- Grid -->
       <div class="p-5">
-        <div v-if="loading || statusLoading" class="flex justify-center py-12">
+        <div v-if="loading" class="flex justify-center py-12">
           <div class="i-svg-spinners-90-ring-with-bg text-4xl text-green-500" />
         </div>
 
@@ -166,26 +161,49 @@ onUnmounted(() => {
           </div>
         </div>
 
-        <div v-else-if="!status?.connection?.connected" class="flex flex-col items-center justify-center gap-4 farm-card rounded-2xl bg-white p-12 text-center text-gray-500 shadow-md dark:bg-gray-800">
+        <div v-else-if="!currentAccount?.running" class="flex flex-col items-center justify-center gap-4 farm-card rounded-2xl bg-white p-12 text-center text-gray-500 shadow-md dark:bg-gray-800">
           <div class="i-carbon-network-4 text-5xl" />
           <div>
             <div class="text-lg text-gray-700 font-medium font-display dark:text-gray-300">
-              账号未登录
+              账号未运行
             </div>
             <div class="font-body mt-1 text-sm text-gray-400">
-              请先运行账号或检查网络连接
+              请先启动账号；启动后会立即读取土地
             </div>
           </div>
         </div>
 
-        <div v-else-if="!lands || lands.length === 0" class="flex flex-col items-center justify-center gap-4 py-16">
-          <div class="i-carbon-sprout text-6xl text-green-500" />
-          <div class="text-lg text-gray-500 font-display">
-            还没有种下作物哦~
+        <div v-else-if="error" class="flex flex-col items-center justify-center gap-3 py-16 text-center text-red-600 dark:text-red-300">
+          <div class="i-carbon-warning-alt text-5xl" />
+          <div class="max-w-xl text-sm">
+            {{ error }}
+          </div>
+          <NButton secondary type="error" @click="refresh">
+            重新读取
+          </NButton>
+        </div>
+
+        <div v-else-if="!loaded" class="flex flex-col items-center justify-center gap-3 py-16 text-center text-gray-500">
+          <div class="i-carbon-data-view-alt text-5xl" />
+          <div class="text-lg font-display">
+            尚未读取土地详情
+          </div>
+          <NButton secondary @click="refresh">
+            立即读取
+          </NButton>
+        </div>
+
+        <div v-else-if="!lands || lands.length === 0" class="flex flex-col items-center justify-center gap-3 py-16 text-center text-gray-500">
+          <div class="i-carbon-sprout text-5xl text-green-500" />
+          <div class="text-lg font-display">
+            当前没有可展示的土地
           </div>
           <div class="font-body text-sm text-gray-400">
-            快去种下第一棵种子吧
+            这不是“尚未种植”的判断，可重新读取确认协议数据
           </div>
+          <NButton secondary @click="refresh">
+            重新读取
+          </NButton>
         </div>
 
         <div v-else class="grid grid-cols-2 gap-4 lg:grid-cols-6 md:grid-cols-4 sm:grid-cols-3">

--- a/web/src/components/LandCard.vue
+++ b/web/src/components/LandCard.vue
@@ -1,8 +1,21 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 
-const props = defineProps<{
+const props = withDefaults(defineProps<{
   land: any
+  selectable?: boolean
+  selected?: boolean
+  selectionDisabled?: boolean
+  selectionLabel?: string
+}>(), {
+  selectable: false,
+  selected: false,
+  selectionDisabled: false,
+  selectionLabel: '',
+})
+
+const emit = defineEmits<{
+  select: [land: any]
 }>()
 
 const land = computed(() => props.land)
@@ -30,7 +43,7 @@ function getLandStatusClass(land: any) {
 
   // 土地等级样式 — soil texture classes
   switch (level) {
-    case 1: // 黄土地
+    case 1: // 普通土地
       baseClass = 'soil-level-1'
       break
     case 2: // 红土地
@@ -82,8 +95,8 @@ function getSafeImageUrl(url: string) {
 
 function getLandTypeName(level: number) {
   const typeMap: Record<number, string> = {
-    0: '普通',
-    1: '黄土地',
+    0: '普通土地',
+    1: '普通土地',
     2: '红土地',
     3: '黑土地',
     4: '金土地',
@@ -102,7 +115,7 @@ function landTypeBadgeClass(level: number) {
   const lv = Number(level) || 0
   const map: Record<number, string> = {
     0: 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300',
-    1: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/40 dark:text-yellow-300',
+    1: 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300',
     2: 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300',
     3: 'bg-slate-200 text-slate-700 dark:bg-slate-700 dark:text-slate-200',
     4: 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300',
@@ -110,22 +123,55 @@ function landTypeBadgeClass(level: number) {
   }
   return map[lv] || map[0]
 }
+
+function activateSelection() {
+  if (props.selectable && !props.selectionDisabled)
+    emit('select', props.land)
+}
 </script>
 
 <template>
   <div
     class="land-card relative min-h-[160px] flex flex-col items-center border-2 cartoon-card rounded-2xl p-3 transition-all duration-300 hover:shadow-lg hover:-translate-y-0.5"
-    :class="getLandStatusClass(land)"
+    :class="[
+      getLandStatusClass(land),
+      {
+        'land-card--selectable': selectable,
+        'land-card--selected': selected,
+        'land-card--selection-disabled': selectable && selectionDisabled,
+      },
+    ]"
+    :role="selectable ? 'button' : undefined"
+    :tabindex="selectable && !selectionDisabled ? 0 : undefined"
+    :aria-pressed="selectable ? selected : undefined"
+    :aria-disabled="selectable ? selectionDisabled : undefined"
+    @click="activateSelection"
+    @keydown.enter.prevent="activateSelection"
+    @keydown.space.prevent="activateSelection"
   >
     <!-- Land ID badge -->
     <div class="absolute left-2 top-2 text-[10px] font-display font-mono opacity-50">
       #{{ land.id }}
     </div>
 
+    <div
+      v-if="selectable"
+      class="selection-cue absolute right-2 top-2"
+      :class="selected ? 'selection-cue--selected' : selectionDisabled ? 'selection-cue--disabled' : 'selection-cue--ready'"
+      :title="selectionLabel || (selected ? '已选择' : selectionDisabled ? '不可选择' : '点击选择')"
+    >
+      <span class="selection-cue__mark">
+        <span v-if="selected" class="i-carbon-checkmark" />
+        <span v-else-if="selectionDisabled" class="i-carbon-subtract" />
+      </span>
+      <span v-if="selectionLabel" class="selection-cue__label">{{ selectionLabel }}</span>
+    </div>
+
     <!-- Plant size badge (joint planting) -->
     <div
       v-if="land.plantSize > 1"
-      class="absolute right-2 top-2 rounded-full bg-pink-100 px-1.5 py-0.5 text-[10px] text-pink-700 font-bold shadow-sm dark:bg-pink-900/30 dark:text-pink-300"
+      class="absolute right-2 rounded-full bg-pink-100 px-1.5 py-0.5 text-[10px] text-pink-700 font-bold shadow-sm dark:bg-pink-900/30 dark:text-pink-300"
+      :class="selectable ? 'top-8' : 'top-2'"
     >
       合种 {{ getPlantSizeText(land) }}
     </div>
@@ -225,8 +271,86 @@ function landTypeBadgeClass(level: number) {
     inset 0 1px 0 rgba(255, 255, 255, 0.38),
     0 8px 20px rgba(40, 48, 44, 0.12);
 }
+.land-card--selectable {
+  cursor: pointer;
+  user-select: none;
+}
+.land-card--selectable:focus-visible {
+  outline: 3px solid rgba(37, 116, 88, 0.34);
+  outline-offset: 3px;
+}
+.land-card--selected {
+  border-color: #257458 !important;
+  box-shadow:
+    inset 0 0 0 2px rgba(255, 255, 255, 0.72),
+    0 0 0 3px rgba(37, 116, 88, 0.2),
+    0 12px 24px rgba(37, 116, 88, 0.18) !important;
+  transform: translateY(-2px);
+}
+.land-card--selection-disabled {
+  cursor: not-allowed;
+  filter: saturate(0.65);
+  opacity: 0.72;
+}
+.selection-cue {
+  z-index: 2;
+  min-height: 22px;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  pointer-events: none;
+  line-height: 1.1;
+}
+.selection-cue--ready {
+  color: #257458;
+}
+.selection-cue--selected {
+  color: #257458;
+}
+.selection-cue--disabled {
+  color: #7d8782;
+}
+.selection-cue__mark {
+  width: 22px;
+  height: 22px;
+  display: grid;
+  place-items: center;
+  border: 1.5px solid currentColor;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.94);
+  box-shadow: 0 2px 7px rgba(40, 62, 53, 0.14);
+}
+.selection-cue__mark > span {
+  font-size: 15px;
+}
+.selection-cue--selected .selection-cue__mark {
+  color: #fff;
+  border-color: #257458;
+  background: #257458;
+}
+.selection-cue--disabled .selection-cue__mark {
+  color: #7d8782;
+  border-color: #aab2ae;
+  background: rgba(239, 242, 240, 0.96);
+}
+.selection-cue__label {
+  padding: 4px 7px;
+  border: 1px solid rgba(37, 116, 88, 0.24);
+  border-radius: 999px;
+  color: #245f4b;
+  background: rgba(244, 252, 247, 0.96);
+  font-size: 10px;
+  font-weight: 700;
+  white-space: nowrap;
+  box-shadow: 0 2px 7px rgba(40, 62, 53, 0.1);
+}
+.selection-cue--disabled .selection-cue__label {
+  border-color: rgba(109, 119, 114, 0.22);
+  color: #69736e;
+  background: rgba(239, 242, 240, 0.96);
+}
 
-.land-card:hover {
+.land-card:hover:not(.land-card--selection-disabled):not(.land-card--selected) {
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.45),
     0 12px 26px rgba(40, 48, 44, 0.16);
@@ -239,12 +363,9 @@ function landTypeBadgeClass(level: number) {
   border-color: #c9b88a;
 }
 .soil-level-1 {
-  /* 黄土地 — warm yellow-brown */
-  background:
-    radial-gradient(ellipse at 20% 80%, rgba(200, 160, 60, 0.25) 0%, transparent 50%),
-    radial-gradient(ellipse at 75% 30%, rgba(180, 140, 50, 0.2) 0%, transparent 45%),
-    linear-gradient(180deg, #f5e6b8 0%, #e0c878 45%, #c8a84a 100%);
-  border-color: #b89838;
+  /* 普通土地 */
+  background: linear-gradient(180deg, #f5f0e8 0%, #e8dcc8 60%, #d4c4a0 100%);
+  border-color: #c9b88a;
 }
 .soil-level-2 {
   /* 红土地 — reddish-brown */
@@ -289,7 +410,7 @@ function landTypeBadgeClass(level: number) {
 
 /* ===== Level-specific border accents ===== */
 .soil-level-1 {
-  border-color: #b89838;
+  border-color: #c9b88a;
 }
 .soil-level-2 {
   border-color: #984828;

--- a/web/src/components/activity/gameplays/qixi/QixiActivityView.vue
+++ b/web/src/components/activity/gameplays/qixi/QixiActivityView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import type { QixiActivityDto } from '@/stores/activity-center'
-import { computed, ref, watch } from 'vue'
+import type { QixiActivityDto, QixiDewTargetsDto } from '@/stores/activity-center'
+import { computed, ref } from 'vue'
+import QixiDewPanel from './QixiDewPanel.vue'
 
 interface FriendOption {
   gid?: string | number
@@ -17,17 +18,23 @@ const props = defineProps<{
   friendsLoading: boolean
   pendingBridge: boolean
   pendingGift: boolean
+  pendingDew: boolean
+  dewTargets: QixiDewTargetsDto | null
+  dewTargetsLoading: boolean
+  dewTargetsError: string
+  dewUsedLandIds: string[]
 }>()
 
 const emit = defineEmits<{
   claimBridge: []
-  gift: [friendGid: string, count: number]
+  gift: [friendGid: string]
+  loadDewTargets: [hostGid: string]
+  useDew: [hostGid: string, landIds: string[]]
   refreshFriends: []
 }>()
 
 const search = ref('')
 const selectedFriendGid = ref('')
-const giftCount = ref(1)
 const failedAvatars = ref(new Set<string>())
 
 const sachetBalance = computed(() => {
@@ -47,14 +54,7 @@ const filteredFriends = computed(() => {
 })
 
 const selectedFriend = computed(() => props.friends.find(friend => String(friend.gid || '') === selectedFriendGid.value) || null)
-const giftDisabled = computed(() => !selectedFriend.value || giftCount.value < 1 || giftCount.value > sachetBalance.value || props.pendingGift || !props.activity?.actions.gift.enabled)
-
-watch(sachetBalance, (balance) => {
-  if (balance <= 0)
-    giftCount.value = 1
-  else if (giftCount.value > balance)
-    giftCount.value = balance
-}, { immediate: true })
+const giftDisabled = computed(() => !selectedFriend.value || sachetBalance.value < 1 || props.pendingGift || !props.activity?.actions.gift.enabled)
 
 function friendName(friend: FriendOption) {
   return String(friend.remark || friend.name || `好友 ${friend.gid || ''}`)
@@ -68,14 +68,9 @@ function chooseFriend(friend: FriendOption) {
   selectedFriendGid.value = String(friend.gid || '')
 }
 
-function setGiftCount(value: unknown) {
-  const parsed = Math.trunc(Number(value))
-  giftCount.value = Math.max(1, Math.min(sachetBalance.value || 1, Number.isFinite(parsed) ? parsed : 1))
-}
-
 function submitGift() {
   if (!giftDisabled.value)
-    emit('gift', selectedFriendGid.value, giftCount.value)
+    emit('gift', selectedFriendGid.value)
 }
 
 function markAvatarFailed(friend: FriendOption) {
@@ -128,6 +123,17 @@ function stageState(stage: QixiActivityDto['bridge']['stages'][number]) {
     </section>
 
     <template v-if="activity">
+      <QixiDewPanel
+        :activity="activity"
+        :targets="dewTargets"
+        :loading="dewTargetsLoading"
+        :pending="pendingDew"
+        :error="dewTargetsError"
+        :used-land-ids="dewUsedLandIds"
+        @load-targets="emit('loadDewTargets', $event)"
+        @use="emit('useDew', $event.hostGid, $event.landIds)"
+      />
+
       <section class="qixi-section bridge-section">
         <div class="section-heading">
           <div>
@@ -140,7 +146,8 @@ function stageState(stage: QixiActivityDto['bridge']['stages'][number]) {
             :disabled="pendingBridge || !activity.actions.bridge.enabled"
             @click="emit('claimBridge')"
           >
-            <span :class="pendingBridge ? 'i-carbon-circle-dash' : 'i-carbon-gift'" />
+            <span v-if="pendingBridge" class="i-carbon-circle-dash animate-spin" />
+            <span v-else class="i-carbon-gift" />
             {{ pendingBridge ? '领取中' : activity.bridge.claimable ? '筑桥并领取' : '暂无奖励' }}
           </button>
         </div>
@@ -180,14 +187,15 @@ function stageState(stage: QixiActivityDto['bridge']['stages'][number]) {
         </div>
       </section>
 
-      <section class="qixi-section gift-section">
+      <section v-if="activity.active" class="qixi-section gift-section">
         <div class="section-heading">
           <div>
             <small>佳节情谊</small>
             <h2>赠送鹊羽香囊</h2>
           </div>
           <button type="button" class="icon-command" :disabled="friendsLoading" title="刷新好友" @click="emit('refreshFriends')">
-            <span :class="friendsLoading ? 'i-carbon-circle-dash' : 'i-carbon-renew'" />
+            <span v-if="friendsLoading" class="i-carbon-circle-dash animate-spin" />
+            <span v-else class="i-carbon-renew" />
           </button>
         </div>
 
@@ -223,7 +231,8 @@ function stageState(stage: QixiActivityDto['bridge']['stages'][number]) {
                   <strong>{{ friendName(friend) }}</strong>
                   <small>GID {{ friend.gid }}<template v-if="friend.level"> · Lv.{{ friend.level }}</template></small>
                 </span>
-                <span class="friend-option__mark" :class="selectedFriendGid === String(friend.gid) ? 'i-carbon-checkmark-filled' : 'i-carbon-chevron-right'" />
+                <span v-if="selectedFriendGid === String(friend.gid)" class="friend-option__mark i-carbon-checkmark-filled" />
+                <span v-else class="friend-option__mark i-carbon-chevron-right" />
               </button>
             </div>
           </div>
@@ -247,22 +256,18 @@ function stageState(stage: QixiActivityDto['bridge']['stages'][number]) {
               </div>
             </div>
 
-            <div class="count-stepper">
-              <button type="button" aria-label="减少赠送数量" :disabled="giftCount <= 1 || pendingGift" @click="setGiftCount(giftCount - 1)">
-                <span class="i-carbon-subtract" />
-              </button>
-              <input :value="giftCount" type="number" inputmode="numeric" min="1" :max="sachetBalance" :disabled="pendingGift" @input="setGiftCount(($event.target as HTMLInputElement).value)">
-              <button type="button" aria-label="增加赠送数量" :disabled="giftCount >= sachetBalance || pendingGift" @click="setGiftCount(giftCount + 1)">
-                <span class="i-carbon-add" />
-              </button>
-              <button type="button" class="max-command" :disabled="sachetBalance <= 0 || giftCount >= sachetBalance || pendingGift" @click="setGiftCount(sachetBalance)">
-                全部
-              </button>
+            <div class="gift-protocol-note">
+              <span class="i-carbon-information" />
+              <div>
+                <strong>每次固定赠送 1 个</strong>
+                <small>使用官方默认祝福文案（ID 15）</small>
+              </div>
             </div>
 
             <button type="button" class="gift-command" :disabled="giftDisabled" @click="submitGift">
-              <span :class="pendingGift ? 'i-carbon-circle-dash' : 'i-carbon-send-alt'" />
-              {{ pendingGift ? '赠送中' : '赠送香囊' }}
+              <span v-if="pendingGift" class="i-carbon-circle-dash animate-spin" />
+              <span v-else class="i-carbon-send-alt" />
+              {{ pendingGift ? '赠送中' : '赠送 1 个香囊' }}
             </button>
           </div>
         </div>
@@ -397,8 +402,7 @@ function stageState(stage: QixiActivityDto['bridge']['stages'][number]) {
 }
 .primary-command:disabled,
 .gift-command:disabled,
-.icon-command:disabled,
-.count-stepper button:disabled {
+.icon-command:disabled {
   opacity: 0.48;
   cursor: not-allowed;
 }
@@ -664,30 +668,32 @@ function stageState(stage: QixiActivityDto['bridge']['stages'][number]) {
   margin-top: 3px;
   font-size: 14px;
 }
-.count-stepper {
-  display: grid;
-  grid-template-columns: 38px minmax(60px, 1fr) 38px 48px;
-  gap: 5px;
-}
-.count-stepper button,
-.count-stepper input {
-  height: 38px;
-  min-width: 0;
-  border: 1px solid #cbd6d1;
+.gift-protocol-note {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 10px 11px;
+  border: 1px solid #d8dfdc;
   border-radius: 6px;
   color: #315d63;
-  background: #f5f8f6;
+  background: #f4f8f6;
 }
-.count-stepper input {
-  width: 100%;
-  padding: 0 6px;
-  background: #fff;
-  font-size: 15px;
-  text-align: center;
+.gift-protocol-note > span {
+  flex: 0 0 auto;
+  font-size: 18px;
 }
-.max-command {
-  font-size: 10px;
-  font-weight: 700;
+.gift-protocol-note div {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+.gift-protocol-note strong {
+  font-size: 11px;
+}
+.gift-protocol-note small {
+  margin-top: 2px;
+  color: #72817f;
+  font-size: 9px;
 }
 .gift-command {
   width: 100%;

--- a/web/src/components/activity/gameplays/qixi/QixiDewPanel.vue
+++ b/web/src/components/activity/gameplays/qixi/QixiDewPanel.vue
@@ -1,0 +1,730 @@
+<script setup lang="ts">
+import type { QixiActivityDto, QixiDewLandTargetDto, QixiDewTargetsDto } from '@/stores/activity-center'
+import { computed, ref, watch } from 'vue'
+import { RouterLink } from 'vue-router'
+
+const props = defineProps<{
+  activity: QixiActivityDto
+  targets: QixiDewTargetsDto | null
+  loading: boolean
+  pending: boolean
+  error: string
+  usedLandIds: string[]
+}>()
+
+const emit = defineEmits<{
+  loadTargets: [hostGid: string]
+  use: [payload: { hostGid: string, landIds: string[] }]
+}>()
+
+const selectedLandIds = ref(new Set<string>())
+
+const usedLandIdSet = computed(() => new Set(props.usedLandIds.map(String)))
+const dewBalance = computed(() => {
+  const value = Number(props.activity.dew.balance || 0)
+  return Number.isSafeInteger(value) && value > 0 ? value : 0
+})
+const selectableTargets = computed(() => (props.targets?.lands || []).filter(target => !usedLandIdSet.value.has(target.landId)))
+const selectedTargets = computed(() => (props.targets?.lands || [])
+  .filter(target => selectedLandIds.value.has(target.landId) && !usedLandIdSet.value.has(target.landId))
+  .sort((left, right) => Number(left.landId) - Number(right.landId)))
+const lifecycle = computed(() => {
+  const now = props.activity.serverTime || Date.now()
+  if (props.activity.startTime && now < props.activity.startTime)
+    return { key: 'upcoming', label: '活动尚未开始', detail: '灵露使用入口暂时关闭' }
+  if (props.activity.active)
+    return { key: 'active', label: '活动期间可使用', detail: '仓库会阻止误售灵露' }
+  if (props.activity.dew.sellable)
+    return { key: 'sellable', label: '活动已结束 · 可手动出售', detail: '不会自动出售，便于保留验证样本' }
+  return { key: 'waiting', label: '活动已结束 · 等待售卖条件', detail: '以服务端 sell_cond 状态为准' }
+})
+const sellPriceText = computed(() => {
+  const price = props.activity.dew.sellPrice
+  if (!price)
+    return ''
+  return `${price.amount} ${price.currencyName || '金币'}/份`
+})
+const useDisabled = computed(() => (
+  selectedTargets.value.length === 0
+  || props.pending
+  || props.loading
+  || !props.activity.actions.dew.enabled
+  || !props.activity.dew.usable
+))
+
+watch(() => props.targets?.host.gid, () => {
+  selectedLandIds.value = new Set()
+})
+
+watch([() => props.targets?.lands, usedLandIdSet], () => {
+  const available = new Set(selectableTargets.value.map(target => target.landId))
+  selectedLandIds.value = new Set([...selectedLandIds.value].filter(landId => available.has(landId)))
+})
+
+function reloadTargets() {
+  emit('loadTargets', '')
+}
+
+function chooseLand(target: QixiDewLandTargetDto) {
+  if (usedLandIdSet.value.has(target.landId))
+    return
+  const next = new Set(selectedLandIds.value)
+  if (next.has(target.landId)) {
+    next.delete(target.landId)
+  }
+  else if (!props.activity.dew.balanceKnown || next.size < dewBalance.value) {
+    next.add(target.landId)
+  }
+  selectedLandIds.value = next
+}
+
+function selectAllAvailable() {
+  const limit = props.activity.dew.balanceKnown ? dewBalance.value : selectableTargets.value.length
+  selectedLandIds.value = new Set(selectableTargets.value.slice(0, limit).map(target => target.landId))
+}
+
+function clearSelection() {
+  selectedLandIds.value = new Set()
+}
+
+function useDew() {
+  const targets = selectedTargets.value
+  if (targets.length === 0 || useDisabled.value)
+    return
+  emit('use', { hostGid: targets[0]!.hostGid, landIds: targets.map(target => target.landId) })
+}
+</script>
+
+<template>
+  <section class="dew-panel">
+    <header class="dew-heading">
+      <div class="dew-title">
+        <span class="dew-orb"><img :src="activity.dew.image" alt=""></span>
+        <div>
+          <small>限时交互道具</small>
+          <h2>{{ activity.dew.name || '鹊羽灵露' }}</h2>
+          <p>活动页操作自己的土地；好友土地与其他特殊道具统一在好友页使用</p>
+        </div>
+      </div>
+      <div class="dew-balance">
+        <span>当前持有</span>
+        <strong>{{ activity.dew.balanceKnown ? (activity.dew.balance || '0') : '--' }}</strong>
+        <small>份</small>
+      </div>
+    </header>
+
+    <div class="dew-lifecycle" :data-state="lifecycle.key">
+      <span class="lifecycle-mark" />
+      <div>
+        <strong>{{ lifecycle.label }}</strong>
+        <small>{{ lifecycle.detail }}</small>
+      </div>
+      <span v-if="sellPriceText" class="sell-price">活动后 {{ sellPriceText }}</span>
+    </div>
+
+    <div v-if="activity.active" class="dew-workbench">
+      <aside class="dew-protocol">
+        <span class="protocol-index">01</span>
+        <h3>使用范围</h3>
+        <div class="farm-scope">
+          <div class="farm-scope__current">
+            <span class="i-carbon-home" />
+            <div>
+              <strong>我的农场</strong>
+              <small>在这里选择自己的地块</small>
+            </div>
+          </div>
+          <RouterLink class="friend-entry" :to="{ name: 'friends' }">
+            <span class="i-carbon-user-multiple" />
+            <span>
+              <strong>前往好友页使用</strong>
+              <small>灵露、黄金虫、足球等统一入口</small>
+            </span>
+            <span class="i-carbon-arrow-right" />
+          </RouterLink>
+        </div>
+
+        <div class="server-note">
+          <span class="i-carbon-security" />
+          <p>这里只筛选自己农场中“已有作物”的候选地块。作物品级（2 品及以下不可用）与重复使用状态由服务器在提交时最终校验。</p>
+        </div>
+      </aside>
+
+      <div class="land-stage">
+        <div class="land-toolbar">
+          <div>
+            <span class="protocol-index">02</span>
+            <h3>选择地块</h3>
+            <small v-if="targets">{{ targets.host.name || (targets.host.isSelf ? '我的农场' : targets.host.gid) }} · {{ targets.count }} 块候选地</small>
+          </div>
+          <div class="land-toolbar-actions">
+            <button type="button" :disabled="loading || selectableTargets.length === 0" @click="selectAllAvailable">
+              全选可用
+            </button>
+            <button type="button" :disabled="selectedTargets.length === 0" @click="clearSelection">
+              清空
+            </button>
+            <button type="button" class="reload-command" :disabled="loading" title="重新读取我的农场" @click="reloadTargets">
+              <span v-if="loading" class="i-carbon-circle-dash animate-spin" />
+              <span v-else class="i-carbon-renew" />
+            </button>
+          </div>
+        </div>
+
+        <div v-if="loading" class="land-state">
+          <span class="i-svg-spinners-90-ring-with-bg" />
+          <strong>正在读取最新地块</strong>
+          <small>正在同步我的农场土地状态</small>
+        </div>
+        <div v-else-if="error" class="land-state land-state--error">
+          <span class="i-carbon-warning-alt" />
+          <strong>{{ error }}</strong>
+          <button type="button" @click="reloadTargets">
+            重新读取
+          </button>
+        </div>
+        <div v-else-if="targets && targets.lands.length === 0" class="land-state">
+          <span class="i-carbon-sprout" />
+          <strong>当前没有已种作物的候选地块</strong>
+          <small>种植后刷新，最终可用性仍以服务器为准</small>
+        </div>
+        <div v-else-if="targets" class="land-grid">
+          <button
+            v-for="target in targets.lands"
+            :key="`${target.hostGid}-${target.landId}`"
+            type="button"
+            class="land-card"
+            :class="{ selected: selectedLandIds.has(target.landId), used: usedLandIdSet.has(target.landId) }"
+            :disabled="usedLandIdSet.has(target.landId)"
+            @click="chooseLand(target)"
+          >
+            <span class="land-number">#{{ target.landId }}</span>
+            <img v-if="target.seedImage" :src="target.seedImage" alt="">
+            <span v-else class="seed-fallback i-carbon-sprout" />
+            <strong>{{ target.plantName }}</strong>
+            <small>{{ target.landTypeName }} · {{ target.phaseName || (target.mature ? '成熟' : '生长中') }}</small>
+            <span v-if="usedLandIdSet.has(target.landId)" class="land-used">本次已使用</span>
+            <span v-else-if="selectedLandIds.has(target.landId)" class="land-check i-carbon-checkmark-filled" />
+            <span v-else class="land-check i-carbon-radio-button" />
+          </button>
+        </div>
+
+        <footer class="dew-submit">
+          <div>
+            <span>即将操作</span>
+            <strong v-if="selectedTargets.length">已选 {{ selectedTargets.length }} 块，将按 #{{ selectedTargets.map(target => target.landId).join(' → #') }} 顺序使用</strong>
+            <strong v-else>尚未选择地块</strong>
+          </div>
+          <button type="button" :disabled="useDisabled" @click="useDew">
+            <span v-if="pending" class="i-carbon-circle-dash animate-spin" />
+            <span v-else class="i-carbon-rain-drop" />
+            {{ pending ? '正在按顺序使用' : `一键使用 ${selectedTargets.length || ''} 份灵露` }}
+          </button>
+        </footer>
+      </div>
+    </div>
+    <div v-else class="dew-archive">
+      <span class="i-carbon-archive" />
+      <div>
+        <strong>活动专属入口已收起</strong>
+        <p>好友页仍会列出背包中可提交的特殊互动道具，能否继续使用由服务端回包判断。剩余材料不会自动出售；满足出售条件后可在仓库中手动处理。</p>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.dew-panel {
+  --dew-ink: #243f41;
+  --dew-green: #2c6663;
+  --dew-pale: #edf5ef;
+  --dew-gold: #c8923b;
+  padding: 26px 28px 28px;
+  border-bottom: 1px solid #cad8d2;
+  color: var(--dew-ink);
+  background:
+    radial-gradient(circle at 90% 0%, rgba(124, 184, 163, 0.2), transparent 27%),
+    linear-gradient(135deg, #f8fbf7 0%, #edf4ee 100%);
+}
+.dew-heading,
+.dew-title,
+.dew-lifecycle,
+.land-toolbar,
+.dew-submit {
+  display: flex;
+  align-items: center;
+}
+.dew-heading {
+  justify-content: space-between;
+  gap: 18px;
+}
+.dew-title {
+  min-width: 0;
+  gap: 14px;
+}
+.dew-orb {
+  width: 64px;
+  height: 64px;
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(44, 102, 99, 0.24);
+  border-radius: 50% 50% 46% 54%;
+  background: rgba(255, 255, 255, 0.74);
+  box-shadow: 0 10px 24px rgba(44, 102, 99, 0.12);
+}
+.dew-orb img {
+  width: 50px;
+  height: 50px;
+  object-fit: contain;
+}
+.dew-title small,
+.protocol-index {
+  color: #8b6152;
+  font-size: 9px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+}
+.dew-title h2,
+.dew-protocol h3,
+.land-toolbar h3 {
+  margin: 2px 0 0;
+  font-size: 20px;
+}
+.dew-title p {
+  margin: 4px 0 0;
+  color: #6e7d79;
+  font-size: 11px;
+}
+.dew-balance {
+  min-width: 104px;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: end;
+  padding: 10px 14px;
+  border-left: 2px solid var(--dew-gold);
+  background: rgba(255, 255, 255, 0.66);
+}
+.dew-balance span {
+  grid-column: 1 / -1;
+  color: #71807d;
+  font-size: 9px;
+}
+.dew-balance strong {
+  color: var(--dew-green);
+  font-size: 25px;
+  line-height: 1;
+}
+.dew-balance small {
+  margin-left: 4px;
+  color: #71807d;
+  font-size: 9px;
+}
+.dew-lifecycle {
+  gap: 9px;
+  margin-top: 16px;
+  padding: 9px 12px;
+  border: 1px solid rgba(44, 102, 99, 0.17);
+  border-radius: 5px;
+  background: rgba(255, 255, 255, 0.68);
+}
+.lifecycle-mark {
+  width: 8px;
+  height: 8px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: #83928f;
+}
+.dew-lifecycle[data-state='active'] .lifecycle-mark {
+  background: #2d8d70;
+  box-shadow: 0 0 0 4px rgba(45, 141, 112, 0.13);
+}
+.dew-lifecycle[data-state='sellable'] .lifecycle-mark {
+  background: var(--dew-gold);
+}
+.dew-lifecycle div {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+.dew-lifecycle strong {
+  font-size: 11px;
+}
+.dew-lifecycle small {
+  margin-top: 1px;
+  color: #71807d;
+  font-size: 9px;
+}
+.sell-price {
+  margin-left: auto;
+  color: #805f29;
+  font-size: 10px;
+  font-weight: 700;
+}
+.dew-workbench {
+  display: grid;
+  grid-template-columns: 230px minmax(0, 1fr);
+  gap: 18px;
+  margin-top: 16px;
+}
+.dew-protocol,
+.land-stage {
+  min-width: 0;
+  border: 1px solid #d4dfda;
+  background: rgba(255, 255, 255, 0.82);
+}
+.dew-protocol {
+  padding: 15px;
+}
+.dew-protocol h3,
+.land-toolbar h3 {
+  font-size: 15px;
+}
+.farm-scope {
+  display: grid;
+  gap: 8px;
+  margin-top: 13px;
+}
+.friend-entry,
+.reload-command,
+.land-state button {
+  border: 1px solid #c9d7d1;
+  color: #496360;
+  background: #f7faf8;
+  cursor: pointer;
+}
+.farm-scope__current,
+.friend-entry {
+  min-height: 52px;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 9px 10px;
+  border-radius: 4px;
+}
+.farm-scope__current {
+  color: #fff;
+  background: var(--dew-green);
+}
+.farm-scope__current > span,
+.friend-entry > span:first-child {
+  flex: 0 0 auto;
+  font-size: 18px;
+}
+.farm-scope__current div,
+.friend-entry > span:nth-child(2) {
+  min-width: 0;
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+}
+.farm-scope strong {
+  font-size: 10px;
+}
+.farm-scope small {
+  margin-top: 2px;
+  font-size: 8px;
+  opacity: 0.78;
+}
+.friend-entry {
+  text-decoration: none;
+  transition:
+    border-color 0.16s ease,
+    background-color 0.16s ease;
+}
+.friend-entry:hover {
+  border-color: var(--dew-green);
+  background: #eff7f2;
+}
+.friend-entry > span:last-child {
+  flex: 0 0 auto;
+  font-size: 14px;
+}
+.server-note {
+  display: flex;
+  gap: 8px;
+  margin-top: 14px;
+  padding-top: 12px;
+  border-top: 1px dashed #cbd8d2;
+  color: #687975;
+}
+.server-note > span {
+  flex: 0 0 auto;
+  color: var(--dew-green);
+  font-size: 16px;
+}
+.server-note p {
+  margin: 0;
+  font-size: 9px;
+  line-height: 1.55;
+}
+.land-stage {
+  display: flex;
+  flex-direction: column;
+}
+.land-toolbar {
+  min-height: 64px;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 14px;
+  border-bottom: 1px solid #d8e1dd;
+}
+.land-toolbar small {
+  display: block;
+  margin-top: 3px;
+  color: #778682;
+  font-size: 9px;
+}
+.reload-command {
+  width: 34px;
+  height: 34px;
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  border-radius: 4px;
+}
+.land-toolbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.land-toolbar-actions > button:not(.reload-command) {
+  min-height: 30px;
+  padding: 0 9px;
+  border: 1px solid #c9d7d1;
+  border-radius: 4px;
+  color: #496360;
+  background: #f7faf8;
+  font-size: 9px;
+  cursor: pointer;
+}
+.land-toolbar-actions > button:disabled {
+  opacity: 0.46;
+  cursor: not-allowed;
+}
+.land-grid {
+  min-height: 164px;
+  max-height: 258px;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(92px, 1fr));
+  gap: 7px;
+  overflow: auto;
+  padding: 12px;
+}
+.land-card {
+  position: relative;
+  min-width: 0;
+  min-height: 116px;
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  justify-content: center;
+  padding: 14px 8px 9px;
+  border: 1px solid #d4dfda;
+  border-radius: 5px;
+  color: var(--dew-ink);
+  background: #f8faf8;
+  cursor: pointer;
+}
+.land-card:hover,
+.land-card.selected {
+  border-color: var(--dew-green);
+  background: #eff7f2;
+}
+.land-card.selected {
+  box-shadow: inset 0 0 0 1px var(--dew-green);
+}
+.land-card.used {
+  border-style: dashed;
+  color: #74817d;
+  background: #edf0ee;
+  cursor: not-allowed;
+  filter: saturate(0.55);
+}
+.land-card img,
+.seed-fallback {
+  width: 42px;
+  height: 42px;
+  object-fit: contain;
+}
+.seed-fallback {
+  display: grid;
+  place-items: center;
+  color: #79a38f;
+  font-size: 29px;
+}
+.land-card strong {
+  max-width: 100%;
+  margin-top: 5px;
+  overflow: hidden;
+  font-size: 10px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.land-card small {
+  margin-top: 2px;
+  color: #788783;
+  font-size: 8px;
+}
+.land-number {
+  position: absolute;
+  top: 6px;
+  left: 7px;
+  color: #7c8a87;
+  font-size: 8px;
+  font-weight: 700;
+}
+.land-check {
+  position: absolute;
+  top: 6px;
+  right: 7px;
+  color: var(--dew-green);
+  font-size: 13px;
+}
+.land-used {
+  position: absolute;
+  right: 6px;
+  bottom: 6px;
+  padding: 2px 5px;
+  border-radius: 8px;
+  color: #5d6b67;
+  background: #dfe5e2;
+  font-size: 7px;
+  font-weight: 700;
+}
+.land-state {
+  min-height: 164px;
+  display: grid;
+  place-content: center;
+  justify-items: center;
+  gap: 5px;
+  padding: 18px;
+  color: #71807d;
+  text-align: center;
+}
+.land-state > span {
+  color: #79a38f;
+  font-size: 25px;
+}
+.land-state strong {
+  max-width: 420px;
+  font-size: 11px;
+}
+.land-state small {
+  font-size: 9px;
+}
+.land-state--error > span {
+  color: #b55f54;
+}
+.land-state button {
+  margin-top: 5px;
+  padding: 5px 10px;
+  border-radius: 4px;
+  font-size: 9px;
+}
+.dew-submit {
+  min-height: 62px;
+  justify-content: space-between;
+  gap: 14px;
+  margin-top: auto;
+  padding: 10px 12px;
+  border-top: 1px solid #d8e1dd;
+  background: #f4f7f5;
+}
+.dew-submit div {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+.dew-submit div span {
+  color: #778682;
+  font-size: 8px;
+}
+.dew-submit div strong {
+  max-width: 100%;
+  margin-top: 3px;
+  overflow: hidden;
+  font-size: 10px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.dew-submit button {
+  min-width: 132px;
+  height: 38px;
+  flex: 0 0 auto;
+  border: 0;
+  border-radius: 4px;
+  color: #fff;
+  background: var(--dew-green);
+  font-size: 11px;
+  font-weight: 700;
+  cursor: pointer;
+}
+.dew-submit button:disabled,
+.reload-command:disabled {
+  opacity: 0.46;
+  cursor: not-allowed;
+}
+.dew-archive {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  margin-top: 16px;
+  padding: 16px;
+  border: 1px dashed #c6d2cd;
+  border-radius: 6px;
+  color: #5f6f6b;
+  background: rgba(255, 255, 255, 0.58);
+}
+.dew-archive > span {
+  flex: 0 0 auto;
+  color: #8b6d3c;
+  font-size: 22px;
+}
+.dew-archive strong {
+  color: var(--dew-ink);
+  font-size: 12px;
+}
+.dew-archive p {
+  margin: 4px 0 0;
+  font-size: 9px;
+  line-height: 1.6;
+}
+@media (max-width: 900px) {
+  .dew-panel {
+    padding: 22px 16px;
+  }
+  .dew-workbench {
+    grid-template-columns: 1fr;
+  }
+  .land-grid {
+    grid-template-columns: repeat(3, minmax(86px, 1fr));
+  }
+  .land-toolbar {
+    align-items: flex-start;
+  }
+  .land-toolbar-actions {
+    flex-wrap: wrap;
+    justify-content: flex-end;
+  }
+}
+@media (max-width: 520px) {
+  .dew-heading,
+  .dew-submit {
+    align-items: stretch;
+    flex-direction: column;
+  }
+  .dew-balance {
+    width: 100%;
+  }
+  .sell-price {
+    display: none;
+  }
+  .land-grid {
+    grid-template-columns: repeat(2, minmax(86px, 1fr));
+  }
+  .dew-submit button {
+    width: 100%;
+  }
+}
+</style>

--- a/web/src/stores/activity-center.ts
+++ b/web/src/stores/activity-center.ts
@@ -220,6 +220,7 @@ export interface ActivityActionsDto {
   exchange: ActivityActionDto
   qixiBridge: ActivityActionDto
   qixiGift: ActivityActionDto
+  qixiDew: ActivityActionDto
 }
 
 export interface QixiBridgeStageDto {
@@ -232,6 +233,59 @@ export interface QixiBridgeStageDto {
   current: boolean
   cost: ActivityItemDto
   rewards: ActivityItemDto[]
+}
+
+export interface QixiGiftExchangeDto {
+  costItems: ActivityItemDto[]
+  receiveItems: ActivityItemDto[]
+  giftType: string
+  content: string
+}
+
+export interface QixiDewDto extends ActivityItemDto {
+  balance: string | null
+  balanceKnown: boolean
+  usable: boolean
+  sellable: boolean
+  sellStatus: string
+  sellCondition: string
+  sellPrice: {
+    currencyId: string
+    amount: string
+    currencyName: string
+    currencyImage: string
+  } | null
+}
+
+export interface QixiDewLandTargetDto {
+  id: string
+  landId: string
+  hostGid: string
+  ownerName: string
+  isSelf: boolean
+  plantId: string
+  plantName: string
+  seedId: string
+  seedImage: string
+  landLevel: number
+  landTypeName: string
+  phaseCode: number
+  phaseName: string
+  mature: boolean
+  occupiedLandIds: string[]
+  activityMarker: string
+}
+
+export interface QixiDewTargetsDto {
+  host: {
+    gid: string
+    name: string
+    avatarUrl: string
+    isSelf: boolean
+  }
+  lands: QixiDewLandTargetDto[]
+  count: number
+  serverValidationRequired: boolean
 }
 
 export interface QixiActivityDto {
@@ -249,10 +303,12 @@ export interface QixiActivityDto {
   feather: ActivityItemDto
   sachet: ActivityItemDto
   receivedSachet: ActivityItemDto
+  dew: QixiDewDto
   balances: {
     feather: string | null
     sachet: string | null
     receivedSachet: string | null
+    dew: string | null
     known: boolean
   }
   bridge: {
@@ -264,18 +320,15 @@ export interface QixiActivityDto {
   }
   gift: {
     sentCount: string
-    field2Code: string
-    field3Code: string
-    exchange: {
-      sentItem: ActivityItemDto
-      receivedItem: ActivityItemDto
-      field3: boolean
-      enabled: boolean
-    }
+    sendLimit: string
+    receiveLimit: string
+    exchanges: QixiGiftExchangeDto[]
+    messageTextId: string
   }
   actions: {
     bridge: ActivityActionDto
     gift: ActivityActionDto
+    dew: ActivityActionDto
   }
 }
 
@@ -334,7 +387,7 @@ export interface ActivityCenterSnapshotDto {
   actions: ActivityActionsDto
 }
 
-export type ActivityMutationKey = 'claimPass' | 'lightConstellation' | 'claimSolar' | 'exchange' | 'claimQixiBridge' | 'giftQixiSachet' | 'claimQingMeiSeed' | 'startQingMeiBrew' | 'continueQingMeiBrew' | 'settleQingMeiBrew'
+export type ActivityMutationKey = 'claimPass' | 'lightConstellation' | 'claimSolar' | 'exchange' | 'claimQixiBridge' | 'giftQixiSachet' | 'useQixiDew' | 'claimQingMeiSeed' | 'startQingMeiBrew' | 'continueQingMeiBrew' | 'settleQingMeiBrew'
 
 function isRecord(value: unknown): value is ActivityRecord {
   return value !== null && typeof value === 'object' && !Array.isArray(value)
@@ -756,8 +809,10 @@ function normalizeQixi(value: unknown): QixiActivityDto | null {
   const balances = record(raw.balances)
   const bridge = record(raw.bridge)
   const gift = record(raw.gift)
-  const exchange = record(gift.exchange)
+  const dew = record(raw.dew)
+  const dewSellPrice = record(first(dew.sellPrice, dew.sell_price))
   const actions = record(raw.actions)
+  const dewBalance = first(dew.balance, balances.dew)
   return {
     groupId: text(raw.groupId, raw.group_id),
     activityId: text(raw.activityId, raw.activity_id, raw.bridgeActivityId, raw.bridge_activity_id),
@@ -773,12 +828,30 @@ function normalizeQixi(value: unknown): QixiActivityDto | null {
     feather: normalizeItem(raw.feather),
     sachet: normalizeItem(raw.sachet),
     receivedSachet: normalizeItem(first(raw.receivedSachet, raw.received_sachet)),
+    dew: {
+      ...normalizeItem(dew),
+      balance: dewBalance === null || dewBalance === undefined ? null : text(dewBalance),
+      balanceKnown: bool(dew.balanceKnown, dew.balance_known, balances.known),
+      usable: bool(dew.usable),
+      sellable: bool(dew.sellable),
+      sellStatus: text(dew.sellStatus, dew.sell_status),
+      sellCondition: text(dew.sellCondition, dew.sell_condition),
+      sellPrice: Object.keys(dewSellPrice).length
+        ? {
+            currencyId: text(dewSellPrice.currencyId, dewSellPrice.currency_id),
+            amount: text(dewSellPrice.amount, dewSellPrice.price),
+            currencyName: text(dewSellPrice.currencyName, dewSellPrice.currency_name),
+            currencyImage: text(dewSellPrice.currencyImage, dewSellPrice.currency_image),
+          }
+        : null,
+    },
     balances: {
       feather: balances.feather === null || balances.feather === undefined ? null : text(balances.feather),
       sachet: balances.sachet === null || balances.sachet === undefined ? null : text(balances.sachet),
       receivedSachet: balances.receivedSachet === null || balances.receivedSachet === undefined
         ? null
         : text(balances.receivedSachet),
+      dew: balances.dew === null || balances.dew === undefined ? null : text(balances.dew),
       known: bool(balances.known),
     },
     bridge: {
@@ -800,19 +873,60 @@ function normalizeQixi(value: unknown): QixiActivityDto | null {
     },
     gift: {
       sentCount: text(gift.sentCount, gift.sent_count),
-      field2Code: text(gift.field2Code, gift.field_2),
-      field3Code: text(gift.field3Code, gift.field_3),
-      exchange: {
-        sentItem: normalizeItem(first(exchange.sentItem, exchange.sent_item)),
-        receivedItem: normalizeItem(first(exchange.receivedItem, exchange.received_item)),
-        field3: bool(exchange.field3, exchange.field_3),
-        enabled: bool(exchange.enabled),
-      },
+      sendLimit: text(gift.sendLimit, gift.send_limit),
+      receiveLimit: text(gift.receiveLimit, gift.receive_limit),
+      exchanges: records(gift.exchanges).map(exchange => ({
+        costItems: records(first(exchange.costItems, exchange.cost_items)).map(normalizeItem),
+        receiveItems: records(first(exchange.receiveItems, exchange.receive_items)).map(normalizeItem),
+        giftType: text(exchange.giftType, exchange.gift_type),
+        content: text(exchange.content),
+      })),
+      messageTextId: text(gift.messageTextId, gift.message_text_id, 15),
     },
     actions: {
       bridge: normalizeAction(actions, {}, ['bridge']),
       gift: normalizeAction(actions, {}, ['gift']),
+      dew: normalizeAction(actions, {}, ['dew']),
     },
+  }
+}
+
+function normalizeQixiDewTargets(value: unknown): QixiDewTargetsDto | null {
+  if (!isRecord(value))
+    return null
+  const raw = value
+  const host = record(raw.host)
+  const lands = records(raw.lands).map((land) => {
+    const rawOccupiedLandIds = first(land.occupiedLandIds, land.occupied_land_ids)
+    return {
+      id: text(land.id, land.landId, land.land_id),
+      landId: text(land.landId, land.land_id, land.id),
+      hostGid: text(land.hostGid, land.host_gid, host.gid),
+      ownerName: text(land.ownerName, land.owner_name, host.name),
+      isSelf: bool(land.isSelf, land.is_self, host.isSelf, host.is_self),
+      plantId: text(land.plantId, land.plant_id),
+      plantName: text(land.plantName, land.plant_name, '未知作物'),
+      seedId: text(land.seedId, land.seed_id),
+      seedImage: text(land.seedImage, land.seed_image),
+      landLevel: finiteNumber(first(land.landLevel, land.land_level)) || 0,
+      landTypeName: text(land.landTypeName, land.land_type_name, '普通土地'),
+      phaseCode: finiteNumber(first(land.phaseCode, land.phase_code)) || 0,
+      phaseName: text(land.phaseName, land.phase_name),
+      mature: bool(land.mature),
+      occupiedLandIds: Array.isArray(rawOccupiedLandIds) ? rawOccupiedLandIds.map(value => text(value)).filter(Boolean) : [],
+      activityMarker: text(land.activityMarker, land.activity_marker),
+    }
+  }).filter(land => land.landId)
+  return {
+    host: {
+      gid: text(host.gid),
+      name: text(host.name, host.remark),
+      avatarUrl: text(host.avatarUrl, host.avatar_url),
+      isSelf: bool(host.isSelf, host.is_self),
+    },
+    lands,
+    count: finiteNumber(raw.count) ?? lands.length,
+    serverValidationRequired: bool(raw.serverValidationRequired, raw.server_validation_required),
   }
 }
 
@@ -941,6 +1055,7 @@ export function normalizeActivitySnapshot(value: unknown): ActivityCenterSnapsho
       exchange: normalizeAction(actionsRaw, capabilitiesRaw, ['exchange', 'shopExchange', 'shop_exchange']),
       qixiBridge: normalizeAction(actionsRaw, capabilitiesRaw, ['qixiBridge', 'qixi_bridge']),
       qixiGift: normalizeAction(actionsRaw, capabilitiesRaw, ['qixiGift', 'qixi_gift']),
+      qixiDew: normalizeAction(actionsRaw, capabilitiesRaw, ['qixiDew', 'qixi_dew']),
     },
   }
 }
@@ -966,10 +1081,19 @@ const activityErrorMessages: Record<string, string> = {
   QIXI_BRIDGE_UNAVAILABLE: '当前没有可领取的鹊桥奖励',
   QIXI_GIFT_UNAVAILABLE: '当前无法赠送鹊羽香囊',
   INVALID_QIXI_FRIEND_GID: '好友信息无效，请重新选择',
-  INVALID_QIXI_SACHET_COUNT: '赠送数量必须是正整数',
+  INVALID_QIXI_MESSAGE_TEXT_ID: '祝福文案信息无效，请刷新活动后重试',
   INSUFFICIENT_QIXI_SACHET: '鹊羽香囊数量不足',
   QIXI_RESPONSE_INVALID: '鹊桥活动数据已经变化，请刷新页面后重试',
   QIXI_GIFT_FAILED: '鹊羽香囊赠送失败，请刷新后重试',
+  QIXI_DEW_ACCOUNT_UNAVAILABLE: '当前账号尚未就绪，请稍后重试',
+  INVALID_QIXI_DEW_HOST_GID: '农场主人信息无效，请重新选择',
+  INVALID_QIXI_DEW_LAND_ID: '地块信息无效，请刷新后重选',
+  INVALID_QIXI_DEW_LAND_IDS: '请选择有效地块，单次最多选择 48 块',
+  QIXI_DEW_UNAVAILABLE: '活动未进行，鹊羽灵露当前不可使用',
+  INSUFFICIENT_QIXI_DEW: '背包中没有可用的鹊羽灵露',
+  QIXI_DEW_SELECTION_EXCEEDS_BALANCE: '所选地块数量超过当前鹊羽灵露余额',
+  QIXI_DEW_HOST_MISMATCH: '进入的农场与所选好友不一致，请刷新后重试',
+  QIXI_DEW_TARGET_UNAVAILABLE: '所选地块已不再可用，请刷新后重选',
   SEASON_UNAVAILABLE: '当前活动数据暂未开放，请稍后刷新重试',
   INVALID_SOLAR_TERM: '节令信息已失效，请刷新页面后重试',
   ACCOUNT_OFFLINE: '当前账号尚未运行，请先启动账号后再试',
@@ -1017,6 +1141,11 @@ export const useActivityCenterStore = defineStore('activity-center', () => {
   const loadedAccountId = ref('')
   const serverClockOffset = ref(0)
   const requestVersion = ref(0)
+  const dewTargets = ref<QixiDewTargetsDto | null>(null)
+  const dewTargetsLoading = ref(false)
+  const dewTargetsError = ref('')
+  const dewUsedLandIdsByInstance = ref<Record<string, string[]>>({})
+  let dewTargetsRequestVersion = 0
   const pendingLoads = new Map<string, Promise<boolean>>()
   const pendingActions = ref<Record<ActivityMutationKey, boolean>>({
     claimPass: false,
@@ -1025,6 +1154,7 @@ export const useActivityCenterStore = defineStore('activity-center', () => {
     exchange: false,
     claimQixiBridge: false,
     giftQixiSachet: false,
+    useQixiDew: false,
     claimQingMeiSeed: false,
     startQingMeiBrew: false,
     continueQingMeiBrew: false,
@@ -1049,6 +1179,7 @@ export const useActivityCenterStore = defineStore('activity-center', () => {
 
   function reset() {
     requestVersion.value += 1
+    dewTargetsRequestVersion += 1
     snapshot.value = normalizeActivitySnapshot({})
     loading.value = false
     error.value = ''
@@ -1056,7 +1187,11 @@ export const useActivityCenterStore = defineStore('activity-center', () => {
     notice.value = ''
     loadedAccountId.value = ''
     serverClockOffset.value = 0
-    pendingActions.value = { claimPass: false, lightConstellation: false, claimSolar: false, exchange: false, claimQixiBridge: false, giftQixiSachet: false, claimQingMeiSeed: false, startQingMeiBrew: false, continueQingMeiBrew: false, settleQingMeiBrew: false }
+    dewTargets.value = null
+    dewTargetsLoading.value = false
+    dewTargetsError.value = ''
+    dewUsedLandIdsByInstance.value = {}
+    pendingActions.value = { claimPass: false, lightConstellation: false, claimSolar: false, exchange: false, claimQixiBridge: false, giftQixiSachet: false, useQixiDew: false, claimQingMeiSeed: false, startQingMeiBrew: false, continueQingMeiBrew: false, settleQingMeiBrew: false }
   }
 
   function clearActionMessages() {
@@ -1157,6 +1292,79 @@ export const useActivityCenterStore = defineStore('activity-center', () => {
     return request
   }
 
+  function clearQixiDewTargets() {
+    dewTargetsRequestVersion += 1
+    dewTargets.value = null
+    dewTargetsLoading.value = false
+    dewTargetsError.value = ''
+  }
+
+  function qixiDewUsageKey(hostGid: string) {
+    const activity = qixi.value
+    return [
+      loadedAccountId.value,
+      activity?.activityId || activity?.groupId || '',
+      activity?.startTime || '',
+      String(hostGid || ''),
+    ].join(':')
+  }
+
+  function getQixiDewUsedLandIds(hostGid: string) {
+    return dewUsedLandIdsByInstance.value[qixiDewUsageKey(hostGid)] || []
+  }
+
+  function recordQixiDewUsage(result: ActivityRecord) {
+    const hostGid = text(result.hostGid, result.host_gid)
+    const rawIds = first(result.usedLandIds, result.used_land_ids)
+    const usedLandIds = Array.isArray(rawIds) ? rawIds.map(value => text(value)).filter(Boolean) : []
+    if (!hostGid || usedLandIds.length === 0)
+      return
+    const key = qixiDewUsageKey(hostGid)
+    const merged = new Set([...(dewUsedLandIdsByInstance.value[key] || []), ...usedLandIds])
+    dewUsedLandIdsByInstance.value = {
+      ...dewUsedLandIdsByInstance.value,
+      [key]: [...merged],
+    }
+  }
+
+  async function fetchQixiDewTargets(accountId: string, hostGid = '') {
+    const requestedAccountId = String(accountId || '').trim()
+    if (!requestedAccountId) {
+      clearQixiDewTargets()
+      dewTargetsError.value = '请先选择账号'
+      return false
+    }
+
+    const version = ++dewTargetsRequestVersion
+    dewTargetsLoading.value = true
+    dewTargetsError.value = ''
+    try {
+      const response = await api.get('/api/activity-center/qixi/dew/targets', {
+        headers: { 'x-account-id': requestedAccountId },
+        params: hostGid ? { hostGid } : {},
+        skipErrorToast: true,
+      } as any)
+      const normalized = normalizeQixiDewTargets(responsePayload(response.data))
+      if (version !== dewTargetsRequestVersion)
+        return false
+      dewTargets.value = normalized
+      if (!normalized)
+        dewTargetsError.value = '未能读取灵露候选地块'
+      return !!normalized
+    }
+    catch (targetError) {
+      if (version === dewTargetsRequestVersion) {
+        dewTargets.value = null
+        dewTargetsError.value = errorMessage(targetError, '加载灵露候选地块失败')
+      }
+      return false
+    }
+    finally {
+      if (version === dewTargetsRequestVersion)
+        dewTargetsLoading.value = false
+    }
+  }
+
   async function mutate(key: ActivityMutationKey, path: string, accountId: string, payload: ActivityRecord = {}) {
     const requestedAccountId = String(accountId || '').trim()
     if (!requestedAccountId || pendingActions.value[key])
@@ -1182,7 +1390,7 @@ export const useActivityCenterStore = defineStore('activity-center', () => {
       const rewards = records(resultRecord.rewards).map(normalizeItem).filter(item => item.id || item.name)
       const rewardSummary = rewards.map(item => `${item.name || item.id}${item.count ? ` ×${item.count}` : ''}`).join('、')
       notice.value = text(resultRecord.message, record(response.data).message, rewardSummary ? `获得 ${rewardSummary}` : '操作成功')
-      return true
+      return resultRecord
     }
     catch (mutationError) {
       if (isCurrent(version, requestedAccountId))
@@ -1214,8 +1422,22 @@ export const useActivityCenterStore = defineStore('activity-center', () => {
     return mutate('claimQixiBridge', '/qixi/bridge/claim', accountId)
   }
 
-  function giftQixiSachet(accountId: string, friendGid: string, count: number) {
-    return mutate('giftQixiSachet', '/qixi/gift', accountId, { friendGid, count })
+  function giftQixiSachet(accountId: string, friendGid: string, messageTextId = 15) {
+    return mutate('giftQixiSachet', '/qixi/gift', accountId, { friendGid, messageTextId })
+  }
+
+  async function useQixiDewBatch(accountId: string, hostGid: string, landIds: string[], refreshTargets = true) {
+    const result = await mutate('useQixiDew', '/qixi/dew/use-batch', accountId, { hostGid, landIds })
+    if (result) {
+      recordQixiDewUsage(result)
+      if (refreshTargets)
+        await fetchQixiDewTargets(accountId, hostGid)
+    }
+    return result
+  }
+
+  function useQixiDew(accountId: string, hostGid: string, landId: string) {
+    return useQixiDewBatch(accountId, hostGid, [landId])
   }
 
   function claimQingMeiDailySeed(accountId: string) {
@@ -1262,6 +1484,10 @@ export const useActivityCenterStore = defineStore('activity-center', () => {
     serverClockOffset,
     serverNow,
     pendingActions,
+    dewTargets,
+    dewTargetsLoading,
+    dewTargetsError,
+    dewUsedLandIdsByInstance,
     lazyLoad,
     refresh,
     claimPass,
@@ -1270,6 +1496,11 @@ export const useActivityCenterStore = defineStore('activity-center', () => {
     exchangeStarSandGoods,
     claimQixiBridgeRewards,
     giftQixiSachet,
+    fetchQixiDewTargets,
+    clearQixiDewTargets,
+    getQixiDewUsedLandIds,
+    useQixiDew,
+    useQixiDewBatch,
     claimQingMeiDailySeed,
     startQingMeiBrew,
     continueQingMeiBrew,

--- a/web/src/stores/farm.ts
+++ b/web/src/stores/farm.ts
@@ -20,23 +20,53 @@ export const useFarmStore = defineStore('farm', () => {
   const seeds = ref<any[]>([])
   const summary = ref<any>({})
   const loading = ref(false)
+  const loaded = ref(false)
+  const error = ref('')
+  let landRequestSequence = 0
 
   async function fetchLands(accountId: string) {
     if (!accountId)
-      return
+      return false
+    const sequence = ++landRequestSequence
     loading.value = true
+    loaded.value = false
+    error.value = ''
     try {
       const { data } = await api.get('/api/lands', {
         headers: { 'x-account-id': accountId },
-      })
+        skipErrorToast: true,
+      } as any)
+      if (sequence !== landRequestSequence)
+        return false
       if (data && data.ok) {
         lands.value = data.data.lands || []
         summary.value = data.data.summary || {}
+        return true
       }
+      error.value = String(data?.error || '无法读取土地数据')
+      return false
+    }
+    catch (cause: any) {
+      if (sequence !== landRequestSequence)
+        return false
+      error.value = String(cause?.response?.data?.error || cause?.message || '无法读取土地数据，请稍后重试')
+      return false
     }
     finally {
-      loading.value = false
+      if (sequence === landRequestSequence) {
+        loaded.value = true
+        loading.value = false
+      }
     }
+  }
+
+  function resetLandState() {
+    landRequestSequence++
+    lands.value = []
+    summary.value = {}
+    loading.value = false
+    loaded.value = false
+    error.value = ''
   }
 
   async function fetchSeeds(accountId: string) {
@@ -58,5 +88,5 @@ export const useFarmStore = defineStore('farm', () => {
     await fetchLands(accountId)
   }
 
-  return { lands, summary, seeds, loading, fetchLands, fetchSeeds, operate }
+  return { lands, summary, seeds, loading, loaded, error, fetchLands, resetLandState, fetchSeeds, operate }
 })

--- a/web/src/stores/friend.ts
+++ b/web/src/stores/friend.ts
@@ -14,15 +14,64 @@ export interface KnownFriendSettings {
   friendsListCacheTtlSec: number
 }
 
+export interface FriendInteractionItemDto {
+  id: string
+  itemId: string
+  name: string
+  image: string
+  count: number
+  saleConditionSatisfiedCount: number
+  interactionType: string
+  protocol: 'item-use'
+  description: string
+  activityId: string
+  sellCondition: string
+  nearestExpireTime: number
+  serverValidationRequired: boolean
+}
+
+export interface FriendInteractionResultDto {
+  landId: string
+  ok: boolean
+  code: string
+  message: string
+}
+
+export interface FriendInteractionBatchDto {
+  hostGid: string
+  ownerName: string
+  itemId: string
+  itemName: string
+  requestedLandIds: string[]
+  usedLandIds: string[]
+  failedLandIds: string[]
+  successCount: number
+  failureCount: number
+  results: FriendInteractionResultDto[]
+  items: FriendInteractionItemDto[]
+  message: string
+}
+
 export const useFriendStore = defineStore('friend', () => {
   const friends = ref<any[]>([])
   const loading = ref(false)
   const friendLands = ref<Record<string, any[]>>({})
   const friendLandsLoading = ref<Record<string, boolean>>({})
+  const friendLandsError = ref<Record<string, string>>({})
+  const friendLandsLoaded = ref<Record<string, boolean>>({})
   const blacklist = ref<BlacklistItem[]>([])
   const interactRecords = ref<any[]>([])
   const interactLoading = ref(false)
   const interactError = ref('')
+  const interactionItems = ref<FriendInteractionItemDto[]>([])
+  const interactionItemsLoading = ref(false)
+  const interactionItemsError = ref('')
+  const interactionUsePending = ref(false)
+  const interactionUseError = ref('')
+  const interactionItemsAccountId = ref('')
+  const interactionUsedLandIds = ref<Record<string, string[]>>({})
+  let friendLandRequestSequence = 0
+  let interactionItemsRequestSequence = 0
 
   const knownFriendGids = ref<number[]>([])
   const knownFriendGidSyncCooldownSec = ref(600)
@@ -149,22 +198,54 @@ export const useFriendStore = defineStore('friend', () => {
 
   async function fetchFriendLands(accountId: string, friendId: string) {
     if (!accountId || !friendId)
-      return
-    friendLandsLoading.value[friendId] = true
+      return false
+    const sequence = ++friendLandRequestSequence
+    const key = String(friendId)
+    friendLandsLoading.value[key] = true
+    friendLandsError.value[key] = ''
+    friendLandsLoaded.value[key] = false
     try {
-      const res = await api.get(`/api/friend/${friendId}/lands`, {
+      const res = await api.get(`/api/friend/${key}/lands`, {
         headers: { 'x-account-id': accountId },
-      })
+        skipErrorToast: true,
+      } as any)
+      if (sequence !== friendLandRequestSequence)
+        return false
       if (res.data.ok) {
         const lands = res.data.data.lands || []
         const summary = res.data.data.summary || null
-        friendLands.value[friendId] = lands
-        syncFriendPlantSummary(friendId, lands, summary)
+        friendLands.value[key] = lands
+        syncFriendPlantSummary(key, lands, summary)
+        return true
       }
+      friendLands.value[key] = []
+      friendLandsError.value[key] = String(res.data?.error || '无法读取好友土地')
+      return false
+    }
+    catch (error: any) {
+      if (sequence !== friendLandRequestSequence)
+        return false
+      friendLands.value[key] = []
+      const rawMessage = String(error?.response?.data?.error || error?.message || '')
+      friendLandsError.value[key] = /gamepb\.|code=\d+|GatewayError/.test(rawMessage)
+        ? '无法进入该好友农场，好友状态可能已变化，请刷新后重试'
+        : (rawMessage || '无法读取好友土地，请稍后重试')
+      return false
     }
     finally {
-      friendLandsLoading.value[friendId] = false
+      if (sequence === friendLandRequestSequence) {
+        friendLandsLoaded.value[key] = true
+        friendLandsLoading.value[key] = false
+      }
     }
+  }
+
+  function resetFriendLandState() {
+    friendLandRequestSequence++
+    friendLands.value = {}
+    friendLandsLoading.value = {}
+    friendLandsError.value = {}
+    friendLandsLoaded.value = {}
   }
 
   async function operate(accountId: string, friendId: string, opType: string) {
@@ -184,6 +265,108 @@ export const useFriendStore = defineStore('friend', () => {
     catch (e: any) {
       return { ok: false, message: e?.response?.data?.error || e?.message || '操作失败' }
     }
+  }
+
+  function interactionUsageKey(accountId: string, itemId: unknown, friendId: unknown) {
+    return `${String(accountId || '')}:${String(itemId || '')}:${String(friendId || '')}`
+  }
+
+  function getInteractionUsedLandIds(accountId: string, itemId: unknown, friendId: unknown) {
+    return interactionUsedLandIds.value[interactionUsageKey(accountId, itemId, friendId)] || []
+  }
+
+  function recordInteractionUsage(accountId: string, result: FriendInteractionBatchDto) {
+    const key = interactionUsageKey(accountId, result.itemId, result.hostGid)
+    const used = new Set(interactionUsedLandIds.value[key] || [])
+    for (const landId of result.usedLandIds || [])
+      used.add(String(landId))
+    interactionUsedLandIds.value = {
+      ...interactionUsedLandIds.value,
+      [key]: [...used].sort((left, right) => Number(left) - Number(right)),
+    }
+  }
+
+  async function fetchInteractionItems(accountId: string) {
+    const requestedAccountId = String(accountId || '').trim()
+    if (!requestedAccountId)
+      return false
+    const sequence = ++interactionItemsRequestSequence
+    if (interactionItemsAccountId.value !== requestedAccountId) {
+      interactionItems.value = []
+      interactionItemsAccountId.value = requestedAccountId
+    }
+    interactionItemsLoading.value = true
+    interactionItemsError.value = ''
+    try {
+      const res = await api.get('/api/friend-interaction-items', {
+        headers: { 'x-account-id': requestedAccountId },
+        skipErrorToast: true,
+      } as any)
+      if (sequence !== interactionItemsRequestSequence)
+        return false
+      if (!res.data?.ok) {
+        interactionItems.value = []
+        interactionItemsError.value = String(res.data?.error || '无法读取特殊互动道具')
+        return false
+      }
+      interactionItems.value = Array.isArray(res.data?.data?.items) ? res.data.data.items : []
+      return true
+    }
+    catch (error: any) {
+      if (sequence !== interactionItemsRequestSequence)
+        return false
+      interactionItems.value = []
+      interactionItemsError.value = String(error?.response?.data?.error || error?.message || '无法读取特殊互动道具')
+      return false
+    }
+    finally {
+      if (sequence === interactionItemsRequestSequence)
+        interactionItemsLoading.value = false
+    }
+  }
+
+  async function useInteractionItemBatch(accountId: string, friendId: string, itemId: string, landIds: string[]) {
+    if (!accountId || !friendId || !itemId || !Array.isArray(landIds) || landIds.length === 0)
+      return false
+    if (interactionUsePending.value)
+      return false
+    interactionUsePending.value = true
+    interactionUseError.value = ''
+    try {
+      const res = await api.post(`/api/friend/${encodeURIComponent(friendId)}/interaction-items/use-batch`, {
+        itemId,
+        landIds,
+      }, {
+        headers: { 'x-account-id': accountId },
+        skipErrorToast: true,
+      } as any)
+      if (!res.data?.ok) {
+        interactionUseError.value = String(res.data?.error || '特殊互动道具使用失败')
+        return false
+      }
+      const result = res.data.data as FriendInteractionBatchDto
+      if (Array.isArray(result?.items))
+        interactionItems.value = result.items
+      recordInteractionUsage(accountId, result)
+      return result
+    }
+    catch (error: any) {
+      interactionUseError.value = String(error?.response?.data?.error || error?.message || '特殊互动道具使用失败')
+      return false
+    }
+    finally {
+      interactionUsePending.value = false
+    }
+  }
+
+  function resetInteractionState() {
+    interactionItemsRequestSequence++
+    interactionItems.value = []
+    interactionItemsLoading.value = false
+    interactionItemsError.value = ''
+    interactionUseError.value = ''
+    interactionItemsAccountId.value = ''
+    interactionUsedLandIds.value = {}
   }
 
   function applyKnownFriendSettings(data: KnownFriendSettings | null | undefined) {
@@ -290,10 +473,17 @@ export const useFriendStore = defineStore('friend', () => {
     loading,
     friendLands,
     friendLandsLoading,
+    friendLandsError,
+    friendLandsLoaded,
     blacklist,
     interactRecords,
     interactLoading,
     interactError,
+    interactionItems,
+    interactionItemsLoading,
+    interactionItemsError,
+    interactionUsePending,
+    interactionUseError,
     knownFriendGids,
     knownFriendGidSyncCooldownSec,
     friendsListCacheTtlSec,
@@ -304,7 +494,12 @@ export const useFriendStore = defineStore('friend', () => {
     toggleBlacklist,
     fetchInteractRecords,
     fetchFriendLands,
+    resetFriendLandState,
     operate,
+    fetchInteractionItems,
+    useInteractionItemBatch,
+    getInteractionUsedLandIds,
+    resetInteractionState,
     fetchKnownFriendSettings,
     saveKnownFriendSettings,
     removeKnownFriendGid,

--- a/web/src/stores/status.ts
+++ b/web/src/stores/status.ts
@@ -41,6 +41,7 @@ export const useStatusStore = defineStore('status', () => {
   const tokenRef = useStorage('admin_token', '')
 
   let socket: Socket | null = null
+  let statusRequestSequence = 0
   let diamondRequestSequence = 0
 
   function normalizeStatusPayload(input: any) {
@@ -70,6 +71,8 @@ export const useStatusStore = defineStore('status', () => {
     if (currentRealtimeAccountId.value && accountId !== currentRealtimeAccountId.value)
       return
     if (body.status && typeof body.status === 'object') {
+      statusRequestSequence++
+      loading.value = false
       status.value = normalizeStatusPayload(body.status)
       error.value = ''
     }
@@ -126,9 +129,20 @@ export const useStatusStore = defineStore('status', () => {
   }
 
   function connectRealtime(accountId: string) {
-    currentRealtimeAccountId.value = String(accountId || '').trim()
+    const nextAccountId = String(accountId || '').trim()
+    const accountChanged = nextAccountId !== currentRealtimeAccountId.value
+    currentRealtimeAccountId.value = nextAccountId
+    if (accountChanged) {
+      statusRequestSequence++
+      status.value = null
+      loading.value = false
+      error.value = ''
+    }
     if (!tokenRef.value)
       return
+
+    if (nextAccountId && (accountChanged || (!status.value && !loading.value)))
+      void fetchStatus(nextAccountId)
 
     const client = ensureRealtimeSocket()
     client.auth = {
@@ -160,11 +174,14 @@ export const useStatusStore = defineStore('status', () => {
   async function fetchStatus(accountId: string) {
     if (!accountId)
       return
+    const sequence = ++statusRequestSequence
     loading.value = true
     try {
       const { data } = await api.get('/api/status', {
         headers: { 'x-account-id': accountId },
       })
+      if (sequence !== statusRequestSequence)
+        return
       if (data.ok) {
         status.value = normalizeStatusPayload(data.data)
         error.value = ''
@@ -174,10 +191,12 @@ export const useStatusStore = defineStore('status', () => {
       }
     }
     catch (e: any) {
-      error.value = e.message
+      if (sequence === statusRequestSequence)
+        error.value = e.message
     }
     finally {
-      loading.value = false
+      if (sequence === statusRequestSequence)
+        loading.value = false
     }
   }
 

--- a/web/src/views/ActivityCenter.vue
+++ b/web/src/views/ActivityCenter.vue
@@ -21,7 +21,7 @@ const accountStore = useAccountStore()
 const activityStore = useActivityCenterStore()
 const friendStore = useFriendStore()
 const { currentAccountId } = storeToRefs(accountStore)
-const { activities, season, shop, solarTerms, constellation, qixi, actions, tabBadges, loading, error, actionError, notice, loadedAccountId, serverClockOffset, pendingActions } = storeToRefs(activityStore)
+const { activities, season, shop, solarTerms, constellation, qixi, actions, tabBadges, loading, error, actionError, notice, loadedAccountId, serverClockOffset, pendingActions, dewTargets, dewTargetsLoading, dewTargetsError } = storeToRefs(activityStore)
 const { friends, loading: friendsLoading } = storeToRefs(friendStore)
 const activeTab = ref<ActivityTab>('travel')
 const selectedActivity = ref<ActivityGameplayKey | null>(null)
@@ -93,6 +93,10 @@ const remaining = computed(() => {
   const minutes = Math.floor(diff % 3600000 / 60000)
   return days > 0 ? `剩余：${days}天${hours}小时` : `剩余：${hours}小时${minutes}分钟`
 })
+const dewUsedLandIds = computed(() => {
+  const hostGid = dewTargets.value?.host.gid || ''
+  return hostGid ? activityStore.getQixiDewUsedLandIds(hostGid) : []
+})
 const balanceVisible = computed(() => activeTab.value === 'travel' || activeTab.value === 'shop')
 
 function accountId() {
@@ -122,18 +126,22 @@ function formatActivityPeriod(activity: ActivityDirectoryItemDto) {
     return `${end} 结束`
   return '活动时间待定'
 }
-function openActivity(activity: ActivityDirectoryItemDto) {
+async function openActivity(activity: ActivityDirectoryItemDto) {
   const gameplay = resolveActivityGameplay(activity)
   if (!gameplay)
     return
   if (gameplay.module.key === 'stellar')
     activeTab.value = gameplay.entryTab as ActivityTab
   selectedActivity.value = gameplay.module.key
-  if (gameplay.module.key === 'qixi' && currentAccountId.value)
-    friendStore.fetchFriends(String(currentAccountId.value))
+  if (gameplay.module.key === 'qixi' && currentAccountId.value) {
+    await activityStore.fetchQixiDewTargets(String(currentAccountId.value), '')
+    await friendStore.fetchFriends(String(currentAccountId.value))
+  }
 }
 function goBack() {
   if (selectedActivity.value) {
+    if (selectedActivity.value === 'qixi')
+      activityStore.clearQixiDewTargets()
     selectedActivity.value = null
     return
   }
@@ -151,12 +159,22 @@ function claimSolar(termId: string) {
 function claimQixiBridge() {
   activityStore.claimQixiBridgeRewards(accountId())
 }
-function giftQixiSachet(friendGid: string, count: number) {
-  activityStore.giftQixiSachet(accountId(), friendGid, count)
+function giftQixiSachet(friendGid: string) {
+  activityStore.giftQixiSachet(accountId(), friendGid)
+}
+function loadQixiDewTargets(hostGid: string) {
+  activityStore.fetchQixiDewTargets(accountId(), hostGid)
+}
+function useQixiDew(hostGid: string, landIds: string[]) {
+  activityStore.useQixiDewBatch(accountId(), hostGid, landIds)
 }
 function refreshQixiFriends() {
   if (currentAccountId.value)
     friendStore.fetchFriends(String(currentAccountId.value), true)
+}
+async function refreshQixiActivity() {
+  await load(true)
+  await activityStore.fetchQixiDewTargets(accountId(), '')
 }
 function selectShopGoods(goods: ShopGoodsDto) {
   selectedShopGoods.value = goods
@@ -226,7 +244,7 @@ onUnmounted(() => {
 <template>
   <section v-if="!selectedActivity" class="activity-picker">
     <button type="button" class="picker-back" aria-label="返回" @click="goBack">
-      ‹
+      <svg viewBox="0 0 24 24" aria-hidden="true"><path d="m14 5-7 7 7 7" /></svg>
     </button>
     <header class="picker-heading">
       <span>活动中心</span>
@@ -327,7 +345,7 @@ onUnmounted(() => {
         :loading="loading"
         show-refresh
         @back="goBack"
-        @refresh="load(true)"
+        @refresh="refreshQixiActivity"
       />
       <div v-if="!currentAccountId" class="activity-state qixi-state">
         <strong>请先选择账号</strong><span>活动数据按当前账号加载</span>
@@ -348,8 +366,15 @@ onUnmounted(() => {
             :friends-loading="friendsLoading"
             :pending-bridge="pendingActions.claimQixiBridge"
             :pending-gift="pendingActions.giftQixiSachet"
+            :pending-dew="pendingActions.useQixiDew"
+            :dew-targets="dewTargets"
+            :dew-targets-loading="dewTargetsLoading"
+            :dew-targets-error="dewTargetsError"
+            :dew-used-land-ids="dewUsedLandIds"
             @claim-bridge="claimQixiBridge"
             @gift="giftQixiSachet"
+            @load-dew-targets="loadQixiDewTargets"
+            @use-dew="useQixiDew"
             @refresh-friends="refreshQixiFriends"
           />
         </main>
@@ -376,13 +401,24 @@ onUnmounted(() => {
   left: 30px;
   width: 40px;
   height: 40px;
+  display: grid;
+  place-items: center;
+  padding: 0;
   border: 1px solid #aec7b8;
   border-radius: 50%;
   color: #315d4c;
   background: #fff;
-  font-size: 30px;
-  line-height: 1;
+  line-height: 0;
   cursor: pointer;
+}
+.picker-back svg {
+  width: 18px;
+  height: 18px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2.4;
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
 .picker-heading {
   width: 100%;

--- a/web/src/views/Friends.vue
+++ b/web/src/views/Friends.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
+import type { FriendInteractionItemDto } from '@/stores/friend'
 import { useIntervalFn } from '@vueuse/core'
 import { NButton, NButtonGroup, NCard, NModal, NPagination, NSpin, NTab, NTabs } from 'naive-ui'
 import { storeToRefs } from 'pinia'
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 import api from '@/api'
 import ConfirmModal from '@/components/ConfirmModal.vue'
 import LandCard from '@/components/LandCard.vue'
@@ -10,13 +11,13 @@ import BaseButton from '@/components/ui/BaseButton.vue'
 import BaseInput from '@/components/ui/BaseInput.vue'
 import BaseTextarea from '@/components/ui/BaseTextarea.vue'
 import { useAccountStore } from '@/stores/account'
+import { useActivityCenterStore } from '@/stores/activity-center'
 import { useFriendStore } from '@/stores/friend'
-import { useStatusStore } from '@/stores/status'
 import { useToastStore } from '@/stores/toast'
 
 const accountStore = useAccountStore()
+const activityStore = useActivityCenterStore()
 const friendStore = useFriendStore()
-const statusStore = useStatusStore()
 const toast = useToastStore()
 const { currentAccountId, currentAccount } = storeToRefs(accountStore)
 const {
@@ -24,18 +25,29 @@ const {
   loading,
   friendLands,
   friendLandsLoading,
+  friendLandsError,
+  friendLandsLoaded,
   blacklist,
   interactRecords,
   interactLoading,
   interactError,
+  interactionItems,
+  interactionItemsLoading,
+  interactionItemsError,
+  interactionUsePending,
+  interactionUseError,
   knownFriendGids,
   knownFriendGidSyncCooldownSec,
   friendsListCacheTtlSec,
   knownFriendSettingsLoading,
   knownFriendSettingsSaving,
 } = storeToRefs(friendStore)
-const { status, loading: statusLoading, realtimeConnected } = storeToRefs(statusStore)
-
+const {
+  qixi,
+  pendingActions: activityPendingActions,
+  actionError: activityActionError,
+  notice: activityNotice,
+} = storeToRefs(activityStore)
 const isQqAccount = computed(() => {
   const acc = currentAccount.value
   if (!acc)
@@ -150,8 +162,27 @@ async function onConfirm() {
 }
 
 const expandedFriends = ref<Set<string>>(new Set())
+const selectedInteractionItemId = ref('')
+const selectedInteractionLandIds = ref<Record<string, string[]>>({})
+const lastInteractionResults = ref<Record<string, Array<{ landId: string, ok: boolean, message: string }>>>({})
+const clockNow = ref(Date.now())
 const currentPage = ref(1)
 const pageSize = 25
+
+const qixiGiftActive = computed(() => {
+  const activity = qixi.value
+  if (!activity?.active)
+    return false
+  return !activity.endTime || clockNow.value < activity.endTime
+})
+const qixiSachetBalance = computed(() => {
+  const value = Number(qixi.value?.balances.sachet || 0)
+  return Number.isSafeInteger(value) && value > 0 ? value : 0
+})
+
+const selectedInteractionItem = computed<FriendInteractionItemDto | null>(() => {
+  return interactionItems.value.find(item => String(item.itemId) === selectedInteractionItemId.value) || null
+})
 
 const sortedFriends = computed(() => {
   return [...friends.value].sort((a: any, b: any) => {
@@ -202,29 +233,176 @@ const filteredInteractRecords = computed(() => {
 
 const visibleInteractRecords = computed(() => filteredInteractRecords.value.slice(0, 50))
 
-async function loadData() {
-  if (currentAccountId.value) {
-    const acc = currentAccount.value
-    if (!acc)
-      return
+function friendKey(friendId: unknown) {
+  return String(friendId || '')
+}
 
-    if (!realtimeConnected.value) {
-      await statusStore.fetchStatus(currentAccountId.value)
-    }
+function interactionSelectionKey(friendId: unknown, itemId: unknown = selectedInteractionItemId.value) {
+  return `${String(itemId || '')}:${friendKey(friendId)}`
+}
 
-    if (acc.running && status.value?.connection?.connected) {
-      avatarErrorKeys.value.clear()
-      friendStore.fetchFriends(currentAccountId.value)
-      friendStore.fetchBlacklist(currentAccountId.value)
-      friendStore.fetchInteractRecords(currentAccountId.value)
-      if (isQqAccount.value) {
-        friendStore.fetchKnownFriendSettings(currentAccountId.value)
-      }
-    }
+function selectedInteractionIds(friendId: unknown, itemId: unknown = selectedInteractionItemId.value) {
+  return selectedInteractionLandIds.value[interactionSelectionKey(friendId, itemId)] || []
+}
+
+function usedInteractionIdSet(friendId: unknown, itemId: unknown = selectedInteractionItemId.value) {
+  if (!currentAccountId.value || !itemId)
+    return new Set<string>()
+  return new Set(friendStore.getInteractionUsedLandIds(currentAccountId.value, itemId, friendKey(friendId)))
+}
+
+function isInteractionLandCandidate(land: any) {
+  return !!land?.unlocked
+    && !land?.occupiedByMaster
+    && !!String(land?.plantName || '').trim()
+    && !['locked', 'empty', 'dead', 'stealable', 'harvested'].includes(String(land?.status || ''))
+}
+
+function isInteractionLandSelected(friendId: unknown, land: any) {
+  return selectedInteractionIds(friendId).includes(String(land?.id || ''))
+}
+
+function isInteractionLandDisabled(friendId: unknown, land: any) {
+  const item = selectedInteractionItem.value
+  return !item
+    || item.count < 1
+    || interactionUsePending.value
+    || !isInteractionLandCandidate(land)
+    || usedInteractionIdSet(friendId, item.itemId).has(String(land?.id || ''))
+}
+
+function interactionLandSelectionLabel(friendId: unknown, land: any) {
+  const landId = String(land?.id || '')
+  if (usedInteractionIdSet(friendId).has(landId))
+    return '本次已用'
+  if (['stealable', 'harvested'].includes(String(land?.status || '')))
+    return '成熟不可放'
+  if (!isInteractionLandCandidate(land))
+    return '不可用'
+  return ''
+}
+
+function setSelectedInteractionIds(friendId: unknown, ids: string[], itemId: unknown = selectedInteractionItemId.value) {
+  const key = interactionSelectionKey(friendId, itemId)
+  selectedInteractionLandIds.value = {
+    ...selectedInteractionLandIds.value,
+    [key]: [...new Set(ids.map(String))].sort((left, right) => Number(left) - Number(right)),
   }
 }
 
+function toggleInteractionLand(friendId: unknown, land: any) {
+  const item = selectedInteractionItem.value
+  if (!item || isInteractionLandDisabled(friendId, land))
+    return
+  const landId = String(land?.id || '')
+  const next = new Set(selectedInteractionIds(friendId, item.itemId))
+  if (next.has(landId)) {
+    next.delete(landId)
+  }
+  else {
+    if (next.size >= item.count) {
+      toast.info(`当前只有 ${item.count} 个${item.name}`)
+      return
+    }
+    next.add(landId)
+  }
+  setSelectedInteractionIds(friendId, [...next], item.itemId)
+}
+
+function selectAllInteractionLands(friendId: unknown) {
+  const item = selectedInteractionItem.value
+  if (!item)
+    return
+  const key = friendKey(friendId)
+  const used = usedInteractionIdSet(key, item.itemId)
+  const candidates = (friendLands.value[key] || [])
+    .filter(land => isInteractionLandCandidate(land) && !used.has(String(land.id)))
+    .sort((left, right) => Number(left.id) - Number(right.id))
+    .slice(0, item.count)
+    .map(land => String(land.id))
+  setSelectedInteractionIds(key, candidates, item.itemId)
+}
+
+function requestUseInteractionItem(friend: any) {
+  const accountId = currentAccountId.value
+  const item = selectedInteractionItem.value
+  if (!accountId || !item)
+    return
+  const key = friendKey(friend?.gid)
+  const landIds = selectedInteractionIds(key, item.itemId)
+  if (landIds.length === 0)
+    return
+  const friendName = String(friend?.name || `GID ${key}`)
+  const saleConditionWarning = item.saleConditionSatisfiedCount > 0
+    ? `该道具库存中有 ${item.saleConditionSatisfiedCount} 个已满足游戏配置的出售条件，可能已过活动或有效期，`
+    : ''
+  confirmAction(
+    `${saleConditionWarning}将在 ${friendName} 的 ${landIds.length} 块土地上按编号依次使用“${item.name}”。作物状态、地块限制及道具时效由服务端最终校验，部分地块可能失败；是否继续？`,
+    async () => {
+      const result = await friendStore.useInteractionItemBatch(accountId, key, item.itemId, landIds)
+      if (!result)
+        throw new Error(interactionUseError.value || `${item.name}使用失败`)
+      lastInteractionResults.value = {
+        ...lastInteractionResults.value,
+        [interactionSelectionKey(key, item.itemId)]: result.results || [],
+      }
+      const used = new Set(result.usedLandIds || [])
+      setSelectedInteractionIds(key, landIds.filter(landId => !used.has(landId)), item.itemId)
+      await friendStore.fetchFriendLands(accountId, key)
+      const successCount = Number(result.successCount || 0)
+      const failureCount = Number(result.failureCount || 0)
+      if (successCount > 0 && failureCount === 0)
+        toast.success(result.message || `已按顺序使用 ${successCount} 个${item.name}`)
+      else if (successCount > 0)
+        toast.warning(result.message || `成功 ${successCount} 块，跳过 ${failureCount} 块`)
+      else
+        toast.warning(result.message || `所选地块当前均不可使用${item.name}`)
+      return result
+    },
+  )
+}
+
+function interactionFailures(friendId: unknown) {
+  const results = lastInteractionResults.value[interactionSelectionKey(friendId)] || []
+  return results.filter(result => !result.ok)
+}
+
+function giftQixiSachetToFriend(friend: any, event: Event) {
+  event.stopPropagation()
+  if (!currentAccountId.value || !qixiGiftActive.value || qixiSachetBalance.value < 1)
+    return
+  const gid = friendKey(friend?.gid)
+  const name = String(friend?.name || `GID ${gid}`)
+  confirmAction(`确定向 ${name} 赠送 1 个鹊羽香囊吗？`, async () => {
+    const result = await activityStore.giftQixiSachet(currentAccountId.value!, gid)
+    if (!result)
+      throw new Error(activityActionError.value || '鹊羽香囊赠送失败')
+    toast.success(activityNotice.value || `已向 ${name} 赠送 1 个鹊羽香囊`)
+    return result
+  })
+}
+
+async function loadData() {
+  const accountId = currentAccountId.value
+  const acc = currentAccount.value
+  if (!accountId || !acc?.running)
+    return
+
+  avatarErrorKeys.value.clear()
+  const requests = [
+    friendStore.fetchFriends(accountId),
+    friendStore.fetchBlacklist(accountId),
+    friendStore.fetchInteractRecords(accountId),
+    friendStore.fetchInteractionItems(accountId),
+    activityStore.lazyLoad(accountId),
+  ]
+  if (isQqAccount.value)
+    requests.push(friendStore.fetchKnownFriendSettings(accountId))
+  await Promise.allSettled(requests)
+}
+
 useIntervalFn(() => {
+  clockNow.value = Date.now()
   for (const gid of expandedFriends.value) {
     for (const land of friendLands.value[gid] || []) {
       if (land.matureInSec > 0)
@@ -233,13 +411,27 @@ useIntervalFn(() => {
   }
 }, 1000)
 
-onMounted(() => {
-  loadData()
-})
-
 watch(currentAccountId, () => {
   expandedFriends.value.clear()
-  loadData()
+  selectedInteractionItemId.value = ''
+  selectedInteractionLandIds.value = {}
+  lastInteractionResults.value = {}
+  friendStore.resetInteractionState()
+  friendStore.resetFriendLandState()
+})
+
+watch([currentAccountId, () => currentAccount.value?.running], () => {
+  void loadData()
+}, { immediate: true })
+
+watch(interactionItems, (items) => {
+  if (!items.some(item => String(item.itemId) === selectedInteractionItemId.value))
+    selectedInteractionItemId.value = String(items[0]?.itemId || '')
+}, { immediate: true })
+
+watch(qixiGiftActive, (active) => {
+  if (!active)
+    activityActionError.value = ''
 })
 
 async function handleRefreshFriends() {
@@ -257,14 +449,20 @@ async function handleRefreshFriends() {
 }
 
 function toggleFriend(friendId: string) {
-  if (expandedFriends.value.has(friendId)) {
-    expandedFriends.value.delete(friendId)
+  const key = friendKey(friendId)
+  if (expandedFriends.value.has(key)) {
+    expandedFriends.value.delete(key)
+    setSelectedInteractionIds(key, [])
   }
   else {
     expandedFriends.value.clear()
-    expandedFriends.value.add(friendId)
-    if (currentAccountId.value && currentAccount.value?.running && status.value?.connection?.connected) {
-      friendStore.fetchFriendLands(currentAccountId.value, friendId)
+    selectedInteractionLandIds.value = {}
+    expandedFriends.value.add(key)
+    if (currentAccountId.value && currentAccount.value?.running) {
+      void Promise.allSettled([
+        friendStore.fetchFriendLands(currentAccountId.value, key),
+        friendStore.fetchInteractionItems(currentAccountId.value),
+      ])
     }
   }
 }
@@ -586,7 +784,7 @@ async function handleBatchAddKnownFriendGids() {
       </NTab>
     </NTabs>
 
-    <div v-if="loading || statusLoading || interactLoading" class="flex justify-center py-12">
+    <div v-if="loading || interactLoading" class="flex justify-center py-12">
       <NSpin size="large" />
     </div>
 
@@ -602,14 +800,14 @@ async function handleBatchAddKnownFriendGids() {
       </div>
     </div>
 
-    <div v-else-if="!status?.connection?.connected" class="flex flex-col items-center justify-center gap-4 farm-card rounded-2xl bg-white p-12 text-center text-gray-500 shadow-md dark:bg-gray-800">
+    <div v-else-if="!currentAccount?.running" class="flex flex-col items-center justify-center gap-4 farm-card rounded-2xl bg-white p-12 text-center text-gray-500 shadow-md dark:bg-gray-800">
       <span class="i-carbon-network-4 text-4xl text-gray-400" />
       <div>
         <div class="text-lg text-gray-700 font-medium dark:text-gray-300">
-          账号未登录
+          账号未运行
         </div>
         <div class="mt-1 text-sm text-gray-400">
-          请先运行账号或检查网络连接
+          请先启动账号；启动后土地请求的具体连接错误会在好友卡片中显示
         </div>
       </div>
     </div>
@@ -749,6 +947,17 @@ async function handleBatchAddKnownFriendGids() {
 
               <div class="flex flex-wrap gap-2">
                 <NButton
+                  v-if="qixiGiftActive"
+                  type="warning"
+                  secondary
+                  size="small"
+                  :disabled="activityPendingActions.giftQixiSachet || qixiSachetBalance < 1"
+                  @click="giftQixiSachetToFriend(friend, $event)"
+                >
+                  <span class="i-carbon-gift mr-1" />
+                  赠香囊 {{ qixiSachetBalance }}
+                </NButton>
+                <NButton
                   type="info"
                   secondary
                   size="small"
@@ -791,20 +1000,117 @@ async function handleBatchAddKnownFriendGids() {
               </div>
             </div>
 
-            <div v-if="expandedFriends.has(friend.gid)" class="border-t bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-900/50">
+            <div v-if="expandedFriends.has(String(friend.gid))" class="border-t bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-900/50">
               <div v-if="friendLandsLoading[friend.gid]" class="flex justify-center py-4">
                 <div class="i-svg-spinners-90-ring-with-bg text-2xl text-blue-500" />
               </div>
-              <div v-else-if="!friendLands[friend.gid] || friendLands[friend.gid]?.length === 0" class="py-4 text-center text-gray-500">
-                无土地数据
+              <div v-else-if="friendLandsError[friend.gid]" class="flex flex-col items-center gap-2 py-5 text-center text-red-600 dark:text-red-300">
+                <span class="i-carbon-warning-alt text-2xl" />
+                <span>{{ friendLandsError[friend.gid] }}</span>
+                <NButton size="small" secondary type="error" @click="currentAccountId && friendStore.fetchFriendLands(currentAccountId, String(friend.gid))">
+                  重新读取
+                </NButton>
               </div>
-              <div v-else class="grid grid-cols-2 gap-2 lg:grid-cols-8 md:grid-cols-5 sm:grid-cols-4">
-                <LandCard
-                  v-for="land in friendLands[friend.gid]"
-                  :key="land.id"
-                  :land="land"
-                />
+              <div v-else-if="!friendLandsLoaded[friend.gid]" class="flex flex-col items-center gap-2 py-5 text-center text-gray-500 dark:text-gray-400">
+                <span class="i-carbon-data-view-alt text-2xl" />
+                <span>尚未读取该好友土地</span>
+                <NButton size="small" secondary @click="currentAccountId && friendStore.fetchFriendLands(currentAccountId, String(friend.gid))">
+                  读取土地
+                </NButton>
               </div>
+              <template v-else>
+                <div class="mb-3 border border-amber-200 rounded-xl bg-amber-50/80 p-3 dark:border-amber-800 dark:bg-amber-950/25">
+                  <div v-if="interactionItemsLoading" class="flex items-center justify-center gap-2 py-2 text-sm text-amber-700 dark:text-amber-300">
+                    <span class="i-svg-spinners-90-ring-with-bg" />
+                    正在读取特殊互动道具
+                  </div>
+                  <div v-else-if="interactionItemsError" class="flex flex-wrap items-center justify-between gap-2 text-sm text-red-600 dark:text-red-300">
+                    <span>{{ interactionItemsError }}</span>
+                    <NButton size="small" secondary type="error" @click="currentAccountId && friendStore.fetchInteractionItems(currentAccountId)">
+                      重新读取
+                    </NButton>
+                  </div>
+                  <template v-else-if="interactionItems.length > 0">
+                    <div class="flex flex-col gap-3 xl:flex-row xl:items-start xl:justify-between">
+                      <div class="min-w-0 flex-1">
+                        <div class="mb-2 flex items-center gap-2 text-sm text-amber-950 font-bold dark:text-amber-100">
+                          <span class="i-carbon-game-console" />
+                          特殊互动道具
+                          <span class="text-xs text-amber-700 font-normal dark:text-amber-300">普通种草、放虫仍由“捣乱”自动化处理</span>
+                        </div>
+                        <div class="flex flex-wrap gap-2">
+                          <button
+                            v-for="item in interactionItems"
+                            :key="item.itemId"
+                            type="button"
+                            class="flex items-center gap-2 border rounded-lg bg-white px-2.5 py-2 text-left transition dark:bg-gray-900"
+                            :class="selectedInteractionItemId === item.itemId
+                              ? 'border-amber-500 ring-2 ring-amber-200 dark:ring-amber-800'
+                              : 'border-amber-200 hover:border-amber-400 dark:border-amber-800'"
+                            :aria-pressed="selectedInteractionItemId === item.itemId"
+                            @click="selectedInteractionItemId = item.itemId"
+                          >
+                            <img :src="item.image" alt="" class="h-8 w-8 object-contain">
+                            <span>
+                              <span class="block text-sm text-gray-800 font-semibold dark:text-gray-100">{{ item.name }}</span>
+                              <span class="block text-xs text-amber-700 dark:text-amber-300">库存 {{ item.count }}</span>
+                            </span>
+                          </button>
+                        </div>
+                        <div v-if="selectedInteractionItem" class="mt-2 text-xs text-amber-800 dark:text-amber-200">
+                          {{ selectedInteractionItem.description || '选择土地后按编号依次使用。' }}
+                          <span class="font-medium">是否可用以服务端回包为准。</span>
+                          <div v-if="selectedInteractionItem.saleConditionSatisfiedCount > 0" class="mt-1 text-red-700 font-medium dark:text-red-300">
+                            其中 {{ selectedInteractionItem.saleConditionSatisfiedCount }} 个已满足游戏配置中的出售条件，可能已过活动或有效期；仍会保留供提交，是否可用由服务端判断。
+                          </div>
+                          <div class="mt-1 text-gray-600 dark:text-gray-300">
+                            当前仅选择生长期作物；实测官方客户端点击成熟作物只进入收获/偷取，不会发出道具使用请求。
+                          </div>
+                        </div>
+                      </div>
+                      <div class="flex shrink-0 flex-wrap gap-2 xl:max-w-72 xl:justify-end">
+                        <NButton size="small" secondary :disabled="!selectedInteractionItem || interactionUsePending" @click="selectAllInteractionLands(friend.gid)">
+                          全选可用
+                        </NButton>
+                        <NButton size="small" secondary :disabled="selectedInteractionIds(friend.gid).length === 0 || interactionUsePending" @click="setSelectedInteractionIds(friend.gid, [])">
+                          清空
+                        </NButton>
+                        <NButton type="warning" size="small" :loading="interactionUsePending" :disabled="!selectedInteractionItem || selectedInteractionIds(friend.gid).length === 0" @click="requestUseInteractionItem(friend)">
+                          按顺序使用 {{ selectedInteractionIds(friend.gid).length || '' }} 个
+                        </NButton>
+                      </div>
+                    </div>
+                    <div v-if="interactionFailures(friend.gid).length > 0" class="mt-3 rounded-lg bg-white/75 px-3 py-2 text-xs text-red-700 dark:bg-gray-900/60 dark:text-red-300">
+                      <div class="mb-1 font-semibold">
+                        未成功的地块
+                      </div>
+                      <div v-for="result in interactionFailures(friend.gid)" :key="`${result.landId}:${result.message}`">
+                        第 {{ result.landId }} 块：{{ result.message }}
+                      </div>
+                    </div>
+                  </template>
+                  <div v-else class="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
+                    <span class="i-carbon-information" />
+                    背包中暂无可用于好友土地的特殊互动道具。
+                  </div>
+                </div>
+
+                <div v-if="!friendLands[friend.gid] || friendLands[friend.gid]?.length === 0" class="py-4 text-center text-gray-500">
+                  该好友当前没有可展示的土地
+                </div>
+                <div v-else class="grid grid-cols-2 gap-2 lg:grid-cols-8 md:grid-cols-5 sm:grid-cols-4">
+                  <LandCard
+                    v-for="land in friendLands[friend.gid]"
+                    :key="land.id"
+                    :land="land"
+                    :selectable="!!selectedInteractionItem"
+                    :selected="isInteractionLandSelected(friend.gid, land)"
+                    :selection-disabled="isInteractionLandDisabled(friend.gid, land)"
+                    :selection-label="interactionLandSelectionLabel(friend.gid, land)"
+                    @select="toggleInteractionLand(friend.gid, land)"
+                  />
+                </div>
+              </template>
             </div>
           </div>
 


### PR DESCRIPTION
## 改动

### 1. 鹊羽灵露（鹊桥寄情活动）

新增 `services/qixi-dew.ts` 与前端 `QixiDewPanel.vue`，补齐活动里灵露的使用链路：

- `GET  /api/activity-center/qixi/dew/targets`：查询指定好友农场里可施露的地块
- `POST /api/activity-center/qixi/dew/use`：单块施露
- `POST /api/activity-center/qixi/dew/use-batch`：批量施露

校验做在服务层：活动开放状态、灵露余额、地块去重、单次上限 48 块，
进入农场后再次校验 host 与所选好友一致（防止中途换农场导致误操作），
批量逐块返回成功/失败并汇总。活动快照补充 dew 余额、可用状态与出售信息。

### 2. 好友特殊互动道具

新增 `services/friend-interaction-items.ts`：

- 列出背包中可作用于好友土地的道具，按过期时间升序（先用快过期的）
- 在**同一次访问会话内**按地块编号顺序批量使用，避免反复进出好友农场
- 同样的入参校验与 48 块上限

好友页统一了互动入口，`itempb` 补充 `UseTarget` 类型。

### 3. 鹊桥协议字段修正

按当前客户端实际抓包对齐，现有实现的这几处字段已经和服务端对不上：

| 位置 | 现有 | 实际 |
| --- | --- | --- |
| 赠送香囊入参 | `friend_gid` / `count` | `target_gid` / `msg_text_id`（单次固定 1 个） |
| 赠送回包 | 依赖 `qixi_gift_result.success` | 该字段已移除，改读 `total_send_count` |
| 鹊桥领奖入参 | `params.claim_mode` | `params.step` |
| 鹊桥领奖回包 | `rewards` / `claimed_stages` | `awards` / `unlocked_steps`，另有 `completed` |
| 赠送配置 | `exchange` 结构 | `total_send_count` / `total_send_limit` / `total_receive_limit` + `gifts` 列表 |

其中赠送回包那处，因为 `success` 字段缺省会被 protobuf 解成 `false`，
当前代码会把**成功的赠送**判定为失败并抛 `QIXI_GIFT_FAILED`。

### 4. 顺带修复两处前端竞态

切换账号时，旧账号的状态请求和土地请求返回得更晚，会覆盖掉新账号的数据。
改为请求序号校验，过期响应直接丢弃。

## 验证

- `pnpm -C core run build:ts` ✅
- `node --test core/tests/*.test.js` → 20/20 通过 ✅（新增 `qixi-dew`、`qixi-dew-lifecycle`、`friend-interaction-items` 三组）
- `pnpm typecheck:web` ✅
- diff 无行尾噪声：`git diff --numstat` 与 `git diff --numstat --ignore-cr-at-eol` 结果一致

## 说明

与另一个 PR（时区统一 / 好友 GID 持久化）互不依赖，可以独立合并。若两个都合，
`services/activity-center.ts` 顶部 import 处会有一个两行的小冲突，我可以随时 rebase。
