### PR TITLE
feat(settings): 静默时段可继续农场巡查

### DIFF
--- a/core/src/core/worker.ts
+++ b/core/src/core/worker.ts
@@ -967,11 +967,17 @@ function syncStatus(force: boolean = false): void {
     const farmRemainSec = Math.max(0, Math.ceil((Number(nextFarmRunAt || 0) - nowMs) / 1000));
     const helpRemainSec = Math.max(0, Math.ceil((Number(nextHelpRunAt || 0) - nowMs) / 1000));
     const stealRemainSec = Math.max(0, Math.ceil((Number(nextStealRunAt || 0) - nowMs) / 1000));
+    const visitStrategy = require('../services/friend/visit-strategy');
+    const friendQuiet = !!visitStrategy.inFriendQuietHours();
+    const farmQuiet = !!visitStrategy.inFarmQuietHours();
     fullStats.nextChecks = {
         farmRemainSec,
         helpRemainSec,
         stealRemainSec,
         friendRemainSec: Math.max(helpRemainSec, stealRemainSec),
+        farmQuiet,
+        helpQuiet: friendQuiet,
+        stealQuiet: friendQuiet,
     };
 
     fullStats.automation = getAutomation();

--- a/core/src/models/store/account-config.ts
+++ b/core/src/models/store/account-config.ts
@@ -142,6 +142,9 @@ function applyConfigSnapshot(snapshot: Record<string, any> | undefined, options:
             enabled: cfg.friendQuietHours.enabled !== undefined ? !!cfg.friendQuietHours.enabled : !!old.enabled,
             start: normalizeTimeString(cfg.friendQuietHours.start, old.start || '23:00'),
             end: normalizeTimeString(cfg.friendQuietHours.end, old.end || '07:00'),
+            continueFarm: cfg.friendQuietHours.continueFarm !== undefined
+                ? !!cfg.friendQuietHours.continueFarm
+                : (old.continueFarm !== undefined ? !!old.continueFarm : true),
         };
     }
 

--- a/core/src/models/store/shared-state.ts
+++ b/core/src/models/store/shared-state.ts
@@ -74,6 +74,7 @@ const DEFAULT_ACCOUNT_CONFIG: AccountConfig = {
         enabled: false,
         start: '01:00',
         end: '07:30',
+        continueFarm: true,
     },
     knownFriendGids: [],
     knownFriendGidSyncCooldownSec: DEFAULT_KNOWN_FRIEND_GID_SYNC_COOLDOWN_SEC,
@@ -222,7 +223,7 @@ function cloneAccountConfig(base: Partial<AccountConfig> = DEFAULT_ACCOUNT_CONFI
         ...base,
         automation,
         intervals: { ...(base.intervals || DEFAULT_ACCOUNT_CONFIG.intervals) },
-        friendQuietHours: { ...(base.friendQuietHours || DEFAULT_ACCOUNT_CONFIG.friendQuietHours) },
+        friendQuietHours: { ...DEFAULT_ACCOUNT_CONFIG.friendQuietHours, ...(base.friendQuietHours || {}) },
         knownFriendGids,
         knownFriendGidSyncCooldownSec,
         friendsListCacheTtlSec,
@@ -289,6 +290,9 @@ function normalizeAccountConfig(input: unknown, fallback: AccountConfig = accoun
             enabled: src.friendQuietHours.enabled !== undefined ? !!src.friendQuietHours.enabled : !!old.enabled,
             start: normalizeTimeString(src.friendQuietHours.start, old.start || '23:00'),
             end: normalizeTimeString(src.friendQuietHours.end, old.end || '07:00'),
+            continueFarm: src.friendQuietHours.continueFarm !== undefined
+                ? !!src.friendQuietHours.continueFarm
+                : (old.continueFarm !== undefined ? !!old.continueFarm : true),
         };
     }
 

--- a/core/src/services/farm/scheduler.ts
+++ b/core/src/services/farm/scheduler.ts
@@ -14,8 +14,8 @@ const { analyzeLands, resolveRemovableHarvestedLands } = require('./land-analysi
 const { autoPlantEmptyLands, runFertilizerByConfig } = require('./planting');
 const { checkAndBuyFertilizerBoth } = require('../mall');
 // 延迟加载以打破循环依赖: visit-strategy → farm/index → scheduler → visit-strategy
-function inFriendQuietHours() {
-    return require('../friend/visit-strategy').inFriendQuietHours();
+function inFarmQuietHours() {
+    return require('../friend/visit-strategy').inFarmQuietHours();
 }
 
 // ============ 内部状态 ============
@@ -32,7 +32,7 @@ let lastPushTime: number = 0;
 async function checkFarm(): Promise<boolean> {
     const state = getUserState();
     if (isCheckingFarm || !state.gid || !isAutomationOn('farm')) return false;
-    if (inFriendQuietHours()) return false;
+    if (inFarmQuietHours()) return false;
     isCheckingFarm = true;
 
     try {

--- a/core/src/services/friend/visit-strategy.ts
+++ b/core/src/services/friend/visit-strategy.ts
@@ -251,6 +251,12 @@ export function inFriendQuietHours(now?: Date): boolean {
     return cur >= start || cur < end; // 跨天时段
 }
 
+export function inFarmQuietHours(now?: Date): boolean {
+    if (!inFriendQuietHours(now)) return false;
+    const cfg: any = getFriendQuietHours();
+    return cfg.continueFarm === false;
+}
+
 // ============ 好友土地分析 ============
 
 interface AnalyzeResult {

--- a/core/src/types/config.ts
+++ b/core/src/types/config.ts
@@ -50,6 +50,7 @@ export interface QuietHoursConfig {
   enabled: boolean;
   start: string;
   end: string;
+  continueFarm: boolean;
 }
 
 export interface AccountConfig {

--- a/web/src/stores/setting.ts
+++ b/web/src/stores/setting.ts
@@ -40,6 +40,7 @@ export interface FriendQuietHoursConfig {
   enabled?: boolean
   start?: string
   end?: string
+  continueFarm?: boolean
 }
 
 export interface OfflineConfig {
@@ -120,7 +121,7 @@ function createDefaultSettings(): SettingsState {
     bagSeedPriority: [],
     bagSeedFallbackStrategy: 'level',
     intervals: {},
-    friendQuietHours: { enabled: false, start: '23:00', end: '07:00' },
+    friendQuietHours: { enabled: false, start: '23:00', end: '07:00', continueFarm: true },
     automation: {},
     ui: {},
     offlineReminder: {
@@ -175,7 +176,10 @@ export const useSettingStore = defineStore('setting', () => {
       bagSeedPriority: cloneValue(data.bagSeedPriority ?? defaults.bagSeedPriority),
       bagSeedFallbackStrategy: data.bagSeedFallbackStrategy ?? defaults.bagSeedFallbackStrategy,
       intervals: cloneValue(data.intervals || defaults.intervals),
-      friendQuietHours: cloneValue(data.friendQuietHours || defaults.friendQuietHours),
+      friendQuietHours: {
+        ...defaults.friendQuietHours,
+        ...(cloneValue(data.friendQuietHours) || {}),
+      },
       automation: cloneValue(data.automation || defaults.automation),
       ui: cloneValue(data.ui || defaults.ui),
       offlineReminder: {

--- a/web/src/views/Dashboard.vue
+++ b/web/src/views/Dashboard.vue
@@ -187,6 +187,9 @@ const localUptime = ref(0)
 let localNextFarmRemainSec = 0
 let localNextHelpRemainSec = 0
 let localNextStealRemainSec = 0
+let farmQuiet = false
+let helpQuiet = false
+let stealQuiet = false
 
 function updateCountdowns() {
   // Update uptime
@@ -197,7 +200,10 @@ function updateCountdowns() {
   }
   else {
     localUptime.value++
-    if (localNextFarmRemainSec > 0) {
+    if (farmQuiet) {
+      nextFarmCheck.value = '静默中'
+    }
+    else if (localNextFarmRemainSec > 0) {
       localNextFarmRemainSec--
       nextFarmCheck.value = formatDuration(localNextFarmRemainSec)
     }
@@ -205,7 +211,10 @@ function updateCountdowns() {
       nextFarmCheck.value = '巡查中...'
     }
 
-    if (localNextHelpRemainSec > 0) {
+    if (helpQuiet) {
+      nextHelpCheck.value = '静默中'
+    }
+    else if (localNextHelpRemainSec > 0) {
       localNextHelpRemainSec--
       nextHelpCheck.value = formatDuration(localNextHelpRemainSec)
     }
@@ -213,7 +222,10 @@ function updateCountdowns() {
       nextHelpCheck.value = '巡查中...'
     }
 
-    if (localNextStealRemainSec > 0) {
+    if (stealQuiet) {
+      nextStealCheck.value = '静默中'
+    }
+    else if (localNextStealRemainSec > 0) {
       localNextStealRemainSec--
       nextStealCheck.value = formatDuration(localNextStealRemainSec)
     }
@@ -231,6 +243,9 @@ watch(() => status.value?.nextChecks, (nextChecks) => {
     localNextFarmRemainSec = nextChecks.farmRemainSec || 0
     localNextHelpRemainSec = nextChecks.helpRemainSec || 0
     localNextStealRemainSec = nextChecks.stealRemainSec || 0
+    farmQuiet = !!nextChecks.farmQuiet
+    helpQuiet = !!nextChecks.helpQuiet
+    stealQuiet = !!nextChecks.stealQuiet
     updateCountdowns() // Update immediately
   }
 }, { immediate: true })

--- a/web/src/views/Settings.vue
+++ b/web/src/views/Settings.vue
@@ -254,7 +254,7 @@ const localStrategySettings = ref({
   plantOrderRandom: false,
   plantDelaySeconds: 0,
   intervals: { farmMin: 2, farmMax: 5, helpMin: 10, helpMax: 15, stealMin: 10, stealMax: 15 },
-  friendQuietHours: { enabled: false, start: '23:00', end: '07:00' },
+  friendQuietHours: { enabled: false, start: '23:00', end: '07:00', continueFarm: true },
 })
 
 const plantingStrategyOptions = [
@@ -677,7 +677,13 @@ function syncLocalStrategySettings() {
       plantOrderRandom: !!settings.value.plantOrderRandom,
       plantDelaySeconds: settings.value.plantDelaySeconds ?? 0,
       intervals: settings.value.intervals,
-      friendQuietHours: settings.value.friendQuietHours,
+      friendQuietHours: {
+        enabled: false,
+        start: '23:00',
+        end: '07:00',
+        continueFarm: true,
+        ...(settings.value.friendQuietHours || {}),
+      },
     }))
   }
 }
@@ -1709,6 +1715,11 @@ async function handleResetSystemConfig() {
                   size="small"
                 />
               </div>
+              <BaseSwitch
+                v-model="localStrategySettings.friendQuietHours.continueFarm"
+                label="静默时继续农场巡查"
+                :disabled="!localStrategySettings.friendQuietHours.enabled"
+              />
             </div>
 
             <div class="border-t pt-3 space-y-3 dark:border-gray-700">


### PR DESCRIPTION
## Summary
- 静默时段新增「静默时继续农场巡查」开关，默认开启
- 开启后静默期内只停自动帮助/偷菜，自家巡田（收获、种菜及整轮 `checkFarm`）继续
- 关掉该开关可恢复静默期内农场也暂停的旧行为；旧配置缺字段按继续巡田处理

## Test plan
- [ ] 设置页开启静默时段后，能看到「静默时继续农场巡查」且默认打开；静默未启用时该开关禁用
- [ ] 保存后，处于静默时段时帮助/偷菜不跑，农场巡查仍会收获和种菜
- [ ] 关掉「静默时继续农场巡查」并保存后，静默时段内农场巡查也停止
- [ ] 未开过该字段的旧账号加载后，开关为开启状态


Made with [Cursor](https://cursor.com)