### PR TITLE
feat: 施肥功能、手动施肥按钮开关与背包种子地块限制

### DIFF
--- a/core/client.ts
+++ b/core/client.ts
@@ -6,9 +6,11 @@ export {};
 const path = require('node:path');
 const fs = require('node:fs');
 
-// Detect if running compiled (dist/) or source (tsx)
+// tsx/bun 直接跑 client.ts 时用 src，避免 stale dist 缺新路由。
+// node client.js / 打包产物仍优先加载已编译的 dist。
+const runningFromSource = /\.[cm]?tsx?$/.test(__filename);
 const distDir = path.join(__dirname, 'dist');
-const baseDir = fs.existsSync(distDir) ? './dist' : './src';
+const baseDir = !runningFromSource && fs.existsSync(distDir) ? './dist' : './src';
 
 const {
     startAdminServer,

--- a/core/src/controllers/admin/account-routes.ts
+++ b/core/src/controllers/admin/account-routes.ts
@@ -98,7 +98,7 @@ function mountAccountRoutes(app: Application, ctx: AdminContext): void {
 
             const data = addOrUpdateAccount(payload);
             if (ctx.provider.addAccountLog) {
-                const accountId = isUpdate ? String(payload.id) : String((data.accounts[data.accounts.length - 1] || {}).id || '');
+                const accountId = isUpdate ? String(payload.id) : String((data.accounts.at(-1) || {}).id || '');
                 const accountName = payload.name || '';
                 ctx.provider.addAccountLog(
                     isUpdate ? 'update' : 'add',
@@ -111,7 +111,7 @@ function mountAccountRoutes(app: Application, ctx: AdminContext): void {
             }
             // 如果是新增，自动启动
             if (!isUpdate) {
-                const newAcc = data.accounts[data.accounts.length - 1];
+                const newAcc = data.accounts.at(-1);
                 if (newAcc) ctx.provider.startAccount(newAcc.id);
             } else if (isRemarkRelogin) {
                 // Adding with an existing remark is a relogin operation, including for stopped accounts.
@@ -367,6 +367,7 @@ function mountAccountRoutes(app: Application, ctx: AdminContext): void {
             const fertilizerBuyNormalThresholdHours = id && (typeof store.getFertilizerBuyNormalThresholdHours === 'function') ? store.getFertilizerBuyNormalThresholdHours(id) : 10;
             const fertilizerBuyCheckIntervalMinutes = id && (typeof store.getFertilizerBuyCheckIntervalMinutes === 'function') ? store.getFertilizerBuyCheckIntervalMinutes(id) : 30;
             const bagSeedPriority = id && (typeof store.getBagSeedPriority === 'function') ? store.getBagSeedPriority(id) : [];
+            const bagSeedLandTypes = id && (typeof store.getBagSeedLandTypes === 'function') ? store.getBagSeedLandTypes(id) : {};
             const bagSeedFallbackStrategy = id && (typeof store.getBagSeedFallbackStrategy === 'function') ? store.getBagSeedFallbackStrategy(id) : 'level';
             const autoAcceptFriendMinLevel = id && (typeof store.getAutoAcceptFriendMinLevel === 'function') ? store.getAutoAcceptFriendMinLevel(id) : 0;
             const autoAcceptRequireOwnLevel = id && (typeof store.getAutoAcceptRequireOwnLevel === 'function') ? store.getAutoAcceptRequireOwnLevel(id) : false;
@@ -377,7 +378,7 @@ function mountAccountRoutes(app: Application, ctx: AdminContext): void {
             const offlineReminder = store.getOfflineReminder
                 ? store.getOfflineReminder()
                 : { channel: 'webhook', endpoint: '', token: '', secret: '', title: '账号下线提醒', msg: '账号下线', offlineDeleteSec: 0 };
-            res.json({ ok: true, data: { intervals, strategy, preferredSeed, friendQuietHours, automation, stealDelaySeconds, plantOrderRandom, plantDelaySeconds, fertilizerBuyOrganicCount, fertilizerBuyOrganicThresholdHours, fertilizerBuyNormalCount, fertilizerBuyNormalThresholdHours, fertilizerBuyCheckIntervalMinutes, bagSeedPriority, bagSeedFallbackStrategy, autoAcceptFriendMinLevel, autoAcceptRequireOwnLevel, autoAcceptHarvestStealEnabled, autoAcceptHarvestStealHarvest, autoAcceptHarvestStealSteal, ui, offlineReminder } });
+            res.json({ ok: true, data: { intervals, strategy, preferredSeed, friendQuietHours, automation, stealDelaySeconds, plantOrderRandom, plantDelaySeconds, fertilizerBuyOrganicCount, fertilizerBuyOrganicThresholdHours, fertilizerBuyNormalCount, fertilizerBuyNormalThresholdHours, fertilizerBuyCheckIntervalMinutes, bagSeedPriority, bagSeedLandTypes, bagSeedFallbackStrategy, autoAcceptFriendMinLevel, autoAcceptRequireOwnLevel, autoAcceptHarvestStealEnabled, autoAcceptHarvestStealHarvest, autoAcceptHarvestStealSteal, ui, offlineReminder } });
         } catch (e: any) {
             res.status(500).json({ ok: false, error: e.message });
         }

--- a/core/src/controllers/admin/farm-routes.ts
+++ b/core/src/controllers/admin/farm-routes.ts
@@ -514,6 +514,19 @@ function mountFarmRoutes(app: Application, ctx: AdminContext): void {
         }
     });
 
+    // API: 对自己农场的指定地块手动施一次化肥。
+    app.post('/api/farm/fertilize', async (req: Request, res: Response) => {
+        const id = getAccId(ctx, req);
+        if (!id) return res.status(400).json({ ok: false, error: 'Missing x-account-id' });
+
+        try {
+            const data = await ctx.provider.fertilizeOwnLand(id, req.body?.landId, req.body?.fertilizerType);
+            res.json({ ok: true, data });
+        } catch (e: any) {
+            handleApiError(res, e);
+        }
+    });
+
     // API: 农场一键操作
     app.post('/api/farm/operate', async (req: Request, res: Response) => {
         const id = getAccId(ctx, req);

--- a/core/src/core/worker.ts
+++ b/core/src/core/worker.ts
@@ -9,7 +9,7 @@ const { getLevelExpProgress, loadConfigs } = require('../config/gameConfig');
 const { getAutomation, getPreferredSeed, getConfigSnapshot, applyConfigSnapshot } = require('../models/store');
 const { checkAndClaimEmails } = require('../services/email');
 const { getEmailDailyState } = require('../services/email');
-const { checkFarm, startFarmCheckLoop, stopFarmCheckLoop, refreshFarmCheckLoop, getLandsDetail, getAvailableSeeds, runFarmOperation, runFertilizerByConfig } = require('../services/farm');
+const { checkFarm, startFarmCheckLoop, stopFarmCheckLoop, refreshFarmCheckLoop, getLandsDetail, getAvailableSeeds, runFarmOperation, runFertilizerByConfig, fertilizeOwnLand } = require('../services/farm');
 const { checkFriends, startFriendCheckLoop, stopFriendCheckLoop, refreshFriendCheckLoop, runBadOnceOnStartup, isHelpExpLimitReached, getFriendsList, getFriendLandsDetail, doFriendOperation, deleteFriend } = require('../services/friend');
 const { getInteractRecords } = require('../services/interact');
 const { processInviteCodes } = require('../services/invite');
@@ -830,6 +830,9 @@ async function handleApiCall(msg: any): Promise<void> {
             }
             case 'doFarmOp':
                 result = await runFarmOperation(args[0]); // opType
+                break;
+            case 'fertilizeOwnLand':
+                result = await fertilizeOwnLand(args[0], args[1]);
                 break;
             case 'buyFertilizer': {
                 const fertilizerType = args[0] || 'organic';

--- a/core/src/core/worker.ts
+++ b/core/src/core/worker.ts
@@ -699,7 +699,7 @@ function handleTerminalDisconnect(payload: any): void {
         connectionId: Number(payload?.connectionId) || 0,
         at: Number(payload?.at) || Date.now(),
     });
-    setTimeout(() => exitWorker(0), 300);
+    setTimeout(exitWorker, 300, 0);
 }
 
 function onKickout(payload: any): void {
@@ -709,7 +709,7 @@ function onKickout(payload: any): void {
     saveStats();
     quiesceBot(`踢下线: ${reason}`);
     sendToMaster({ type: 'account_kicked', reason });
-    setTimeout(() => exitWorker(0), 300);
+    setTimeout(exitWorker, 300, 0);
 }
 
 // 处理来自 Admin 面板的直接调用请求 (如: 购买种子、开关设置等)
@@ -986,8 +986,8 @@ async function getDailyGiftOverview(): Promise<any> {
                 enabled: true,
                 doneToday: !!vip.doneToday,
                 lastAt: Number(vip.lastClaimAt || vip.lastCheckAt || 0),
-                hasGift: Object.prototype.hasOwnProperty.call(vip, 'hasGift') ? !!vip.hasGift : undefined,
-                canClaim: Object.prototype.hasOwnProperty.call(vip, 'canClaim') ? !!vip.canClaim : undefined,
+                hasGift: Object.hasOwn(vip, 'hasGift') ? !!vip.hasGift : undefined,
+                canClaim: Object.hasOwn(vip, 'canClaim') ? !!vip.canClaim : undefined,
                 result: vip.result || '',
             },
             {
@@ -996,8 +996,8 @@ async function getDailyGiftOverview(): Promise<any> {
                 enabled: true,
                 doneToday: !!month.doneToday,
                 lastAt: Number(month.lastClaimAt || month.lastCheckAt || 0),
-                hasCard: Object.prototype.hasOwnProperty.call(month, 'hasCard') ? !!month.hasCard : undefined,
-                hasClaimable: Object.prototype.hasOwnProperty.call(month, 'hasClaimable') ? !!month.hasClaimable : undefined,
+                hasCard: Object.hasOwn(month, 'hasCard') ? !!month.hasCard : undefined,
+                hasClaimable: Object.hasOwn(month, 'hasClaimable') ? !!month.hasClaimable : undefined,
                 result: month.result || '',
             },
         ],

--- a/core/src/models/store/account-config.ts
+++ b/core/src/models/store/account-config.ts
@@ -1,4 +1,4 @@
-import type { AccountConfig, AutomationConfig, BagSeedFallbackStrategy, IntervalConfig, PlantingStrategy, QuietHoursConfig } from '../../types/config';
+import type { AccountConfig, AutomationConfig, BagSeedFallbackStrategy, FertilizerLandType, IntervalConfig, PlantingStrategy, QuietHoursConfig } from '../../types/config';
 export {};
 
 const sharedState = require('./shared-state');
@@ -13,6 +13,7 @@ const {
     normalizeKnownFriendGidSyncCooldownSec,
     normalizeFriendsListCacheTtlSec,
     normalizeBagSeedPriority,
+    normalizeBagSeedLandTypes,
     normalizeBagSeedFallbackStrategy,
     normalizeIntervals,
     normalizeTimeString,
@@ -21,6 +22,14 @@ const {
     normalizeAutoAcceptHarvestStealSteal,
     ALLOWED_PLANTING_STRATEGIES,
 } = sharedState;
+
+function cloneBagSeedLandTypes(input: Record<string, FertilizerLandType[]> | undefined): Record<string, FertilizerLandType[]> {
+    const cloned: Record<string, FertilizerLandType[]> = {};
+    for (const [seedId, types] of Object.entries(input || {})) {
+        cloned[seedId] = [...(types || [])];
+    }
+    return cloned;
+}
 
 function getAccountConfigSnapshot(accountId?: unknown): AccountConfig {
     const id = sharedState.resolveAccountId(accountId);
@@ -89,6 +98,7 @@ function getConfigSnapshot(accountId?: unknown): AccountConfig & { ui: typeof gl
         fertilizerBuyNormalThresholdHours: Math.max(0, Math.min(990, Number(cfg.fertilizerBuyNormalThresholdHours) || 0)),
         fertilizerBuyCheckIntervalMinutes: Math.max(1, Math.min(1440, Number(cfg.fertilizerBuyCheckIntervalMinutes) || 30)),
         bagSeedPriority: [...(cfg.bagSeedPriority || [])],
+        bagSeedLandTypes: cloneBagSeedLandTypes(cfg.bagSeedLandTypes),
         bagSeedFallbackStrategy: cfg.bagSeedFallbackStrategy,
         autoAcceptFriendMinLevel: cfg.autoAcceptFriendMinLevel,
         autoAcceptRequireOwnLevel: !!cfg.autoAcceptRequireOwnLevel,
@@ -221,6 +231,10 @@ function applyConfigSnapshot(snapshot: Record<string, any> | undefined, options:
         next.bagSeedPriority = normalizeBagSeedPriority(cfg.bagSeedPriority);
     }
 
+    if (cfg.bagSeedLandTypes !== undefined && cfg.bagSeedLandTypes !== null) {
+        next.bagSeedLandTypes = normalizeBagSeedLandTypes(cfg.bagSeedLandTypes);
+    }
+
     if (cfg.bagSeedFallbackStrategy !== undefined && cfg.bagSeedFallbackStrategy !== null) {
         next.bagSeedFallbackStrategy = normalizeBagSeedFallbackStrategy(cfg.bagSeedFallbackStrategy, next.bagSeedFallbackStrategy);
     }
@@ -281,6 +295,10 @@ function getPlantingStrategy(accountId?: unknown): PlantingStrategy {
 
 function getBagSeedPriority(accountId?: unknown): number[] {
     return [...(getAccountConfigSnapshot(accountId).bagSeedPriority || [])];
+}
+
+function getBagSeedLandTypes(accountId?: unknown): Record<string, FertilizerLandType[]> {
+    return cloneBagSeedLandTypes(getAccountConfigSnapshot(accountId).bagSeedLandTypes);
 }
 
 function getBagSeedFallbackStrategy(accountId?: unknown): BagSeedFallbackStrategy {
@@ -456,6 +474,7 @@ module.exports = {
     getPreferredSeed,
     getPlantingStrategy,
     getBagSeedPriority,
+    getBagSeedLandTypes,
     getBagSeedFallbackStrategy,
     getIntervals,
     getFriendQuietHours,

--- a/core/src/models/store/index.ts
+++ b/core/src/models/store/index.ts
@@ -14,6 +14,7 @@ module.exports = {
     getPreferredSeed: accountConfig.getPreferredSeed,
     getPlantingStrategy: accountConfig.getPlantingStrategy,
     getBagSeedPriority: accountConfig.getBagSeedPriority,
+    getBagSeedLandTypes: accountConfig.getBagSeedLandTypes,
     getBagSeedFallbackStrategy: accountConfig.getBagSeedFallbackStrategy,
     getIntervals: accountConfig.getIntervals,
     getFriendQuietHours: accountConfig.getFriendQuietHours,

--- a/core/src/models/store/shared-state.ts
+++ b/core/src/models/store/shared-state.ts
@@ -72,6 +72,7 @@ const DEFAULT_ACCOUNT_CONFIG: AccountConfig = {
         fertilizer_land_types: [...DEFAULT_FERTILIZER_LAND_TYPES],
         fertilizer_smart_seconds: 300,
         skip_own_weed_bug: true,
+        show_manual_fertilizer: true,
     },
     plantingStrategy: 'max_exp',
     preferredSeedId: 0,

--- a/core/src/models/store/shared-state.ts
+++ b/core/src/models/store/shared-state.ts
@@ -113,6 +113,7 @@ const DEFAULT_ACCOUNT_CONFIG: AccountConfig = {
     fertilizerBuyNormalThresholdHours: 10,
     fertilizerBuyCheckIntervalMinutes: 60,
     bagSeedPriority: [],
+    bagSeedLandTypes: {},
     bagSeedFallbackStrategy: 'level',
     autoAcceptFriendMinLevel: 0,
     autoAcceptRequireOwnLevel: false,
@@ -175,6 +176,29 @@ function normalizeBagSeedPriority(input: unknown): number[] {
         if (!Number.isFinite(value) || value <= 0) continue;
         if (normalized.includes(value)) continue;
         normalized.push(value);
+    }
+    return normalized;
+}
+
+/**
+ * seedId -> 允许的土地类型。缺 key、空数组、全类型三者等价于不限制，统一省略该 key。
+ */
+function normalizeBagSeedLandTypes(input: unknown): Record<string, FertilizerLandType[]> {
+    if (!input || typeof input !== 'object' || Array.isArray(input)) return {};
+    const normalized: Record<string, FertilizerLandType[]> = {};
+    for (const [key, value] of Object.entries(input as Record<string, unknown>)) {
+        const seedId = Number.parseInt(key, 10);
+        if (!Number.isFinite(seedId) || seedId <= 0) continue;
+        if (!Array.isArray(value)) continue;
+        const types: FertilizerLandType[] = [];
+        for (const item of value) {
+            const type = String(item || '').trim().toLowerCase();
+            if (!FERTILIZER_LAND_TYPE_SET.has(type)) continue;
+            if (types.includes(type as FertilizerLandType)) continue;
+            types.push(type as FertilizerLandType);
+        }
+        if (types.length === 0 || types.length === DEFAULT_FERTILIZER_LAND_TYPES.length) continue;
+        normalized[String(seedId)] = types;
     }
     return normalized;
 }
@@ -280,6 +304,7 @@ function cloneAccountConfig(base: Partial<AccountConfig> = DEFAULT_ACCOUNT_CONFI
         fertilizerBuyNormalThresholdHours: Math.max(0, Math.min(990, Number(base.fertilizerBuyNormalThresholdHours) || 0)),
         fertilizerBuyCheckIntervalMinutes: Math.max(1, Math.min(1440, Number(base.fertilizerBuyCheckIntervalMinutes) || 30)),
         bagSeedPriority: normalizeBagSeedPriority(base.bagSeedPriority),
+        bagSeedLandTypes: normalizeBagSeedLandTypes(base.bagSeedLandTypes),
         bagSeedFallbackStrategy: normalizeBagSeedFallbackStrategy(base.bagSeedFallbackStrategy),
         autoAcceptFriendMinLevel: normalizeAutoAcceptFriendMinLevel(base.autoAcceptFriendMinLevel, DEFAULT_ACCOUNT_CONFIG.autoAcceptFriendMinLevel),
         autoAcceptRequireOwnLevel: !!base.autoAcceptRequireOwnLevel,
@@ -401,6 +426,10 @@ function normalizeAccountConfig(input: unknown, fallback: AccountConfig = accoun
 
     if (src.bagSeedPriority !== undefined && src.bagSeedPriority !== null) {
         cfg.bagSeedPriority = normalizeBagSeedPriority(src.bagSeedPriority);
+    }
+
+    if (src.bagSeedLandTypes !== undefined && src.bagSeedLandTypes !== null) {
+        cfg.bagSeedLandTypes = normalizeBagSeedLandTypes(src.bagSeedLandTypes);
     }
 
     if (src.bagSeedFallbackStrategy !== undefined && src.bagSeedFallbackStrategy !== null) {
@@ -555,6 +584,7 @@ module.exports = {
     normalizeKnownFriendGidSyncCooldownSec,
     normalizeFriendsListCacheTtlSec,
     normalizeBagSeedPriority,
+    normalizeBagSeedLandTypes,
     normalizeBagSeedFallbackStrategy,
     normalizeFertilizerLandTypes,
     normalizeTimeString,

--- a/core/src/runtime/data-provider.ts
+++ b/core/src/runtime/data-provider.ts
@@ -221,15 +221,15 @@ function createDataProvider(options: DataProviderOptions) {
             const body = (payload && typeof payload === 'object') ? payload : {};
             const snapshot: Record<string, any> = {};
             const copyIfPresent = (sourceKey: string, targetKey: string = sourceKey): void => {
-                if (Object.prototype.hasOwnProperty.call(body, sourceKey)) {
+                if (Object.hasOwn(body, sourceKey)) {
                     snapshot[targetKey] = body[sourceKey];
                 }
             };
 
             copyIfPresent('plantingStrategy');
-            if (!Object.prototype.hasOwnProperty.call(snapshot, 'plantingStrategy')) copyIfPresent('strategy', 'plantingStrategy');
+            if (!Object.hasOwn(snapshot, 'plantingStrategy')) copyIfPresent('strategy', 'plantingStrategy');
             copyIfPresent('preferredSeedId');
-            if (!Object.prototype.hasOwnProperty.call(snapshot, 'preferredSeedId')) copyIfPresent('seedId', 'preferredSeedId');
+            if (!Object.hasOwn(snapshot, 'preferredSeedId')) copyIfPresent('seedId', 'preferredSeedId');
             for (const key of [
                 'automation',
                 'intervals',
@@ -243,6 +243,7 @@ function createDataProvider(options: DataProviderOptions) {
                 'fertilizerBuyNormalThresholdHours',
                 'fertilizerBuyCheckIntervalMinutes',
                 'bagSeedPriority',
+                'bagSeedLandTypes',
                 'bagSeedFallbackStrategy',
                 'autoAcceptFriendMinLevel',
                 'autoAcceptRequireOwnLevel',

--- a/core/src/runtime/data-provider.ts
+++ b/core/src/runtime/data-provider.ts
@@ -206,6 +206,9 @@ function createDataProvider(options: DataProviderOptions) {
         },
 
         doFarmOp: (accountRef: string, opType: string) => callWorkerApi(resolveAccountRefId(accountRef), 'doFarmOp', opType),
+        fertilizeOwnLand: (accountRef: string, landId: unknown, fertilizerType: unknown) => (
+            callWorkerApi(resolveAccountRefId(accountRef), 'fertilizeOwnLand', landId, fertilizerType)
+        ),
 
         doAnalytics: (accountRef: string, sortBy: string) => callWorkerApi(resolveAccountRefId(accountRef), 'getAnalytics', sortBy),
         buyFertilizer: (accountRef: string, type: string, count: number) => callWorkerApi(resolveAccountRefId(accountRef), 'buyFertilizer', type, count),

--- a/core/src/services/commerce.ts
+++ b/core/src/services/commerce.ts
@@ -80,7 +80,7 @@ function mallGoodsDto(goods: any, balances: Record<string, number>): any {
     const limit = limitDto(goods?.purchase_limit);
     const isFree = !!goods?.is_free || price.id === 0 || price.count === 0;
     const available = goods?.is_available !== false;
-    const balance = price.id > 0 && Object.prototype.hasOwnProperty.call(balances, String(price.id))
+    const balance = price.id > 0 && Object.hasOwn(balances, String(price.id))
         ? balances[String(price.id)]
         : null;
     return {
@@ -112,7 +112,7 @@ async function getMallCatalog(slotTypeInput: unknown = 1, subSlotTypeInput: unkn
         subSlotType,
         serverTime: getServerTimeSec() * 1000,
         refreshCountdown: Math.max(0, toNum(reply?.refresh_countdown)),
-        currencies: [...new Set(currencyIds)].map(id => ({ ...itemDto({ id, count: balances[String(id)] || 0 }), balanceKnown: Object.prototype.hasOwnProperty.call(balances, String(id)) })),
+        currencies: Array.from(new Set(currencyIds), id => ({ ...itemDto({ id, count: balances[String(id)] || 0 }), balanceKnown: Object.hasOwn(balances, String(id)) })),
         goods: goods.map((entry: any) => mallGoodsDto(entry, balances)),
     };
 }

--- a/core/src/services/farm/api.ts
+++ b/core/src/services/farm/api.ts
@@ -86,6 +86,19 @@ const ORGANIC_FERTILIZER_ID: number = 1012;
 const MAX_ORGANIC_FERTILIZE_OPERATIONS: number = 240;
 const MAX_ORGANIC_FERTILIZE_ROUNDS: number = 20;
 
+async function fertilizeOne(landId: number, fertilizerId: number = NORMAL_FERTILIZER_ID): Promise<any> {
+    const body = types.FertilizeRequest.encode(types.FertilizeRequest.create({
+        land_ids: [toLong(landId)],
+        fertilizer_id: toLong(fertilizerId),
+    })).finish();
+    const { body: replyBody } = await sendMsgAsync('gamepb.plantpb.PlantService', 'Fertilize', body);
+    const reply = types.FertilizeReply.decode(replyBody);
+    if (reply.operation_limits && onOperationLimitsUpdate) {
+        onOperationLimitsUpdate(reply.operation_limits);
+    }
+    return reply;
+}
+
 /**
  * 施肥 - 必须逐块进行，服务器不支持批量
  * 游戏中拖动施肥间隔很短，这里用 50ms
@@ -224,6 +237,7 @@ module.exports = {
     waterLand,
     farming,
     encodeOwnFarmingRequest,
+    fertilizeOne,
     fertilize,
     fertilizeOrganicLoop,
     removePlant,

--- a/core/src/services/farm/index.ts
+++ b/core/src/services/farm/index.ts
@@ -25,6 +25,7 @@ module.exports = {
     getAvailableSeeds: planting.getAvailableSeeds,
     runFarmOperation: scheduler.runFarmOperation,
     runFertilizerByConfig: planting.runFertilizerByConfig,
+    fertilizeOwnLand: planting.fertilizeOwnLand,
     buildLandMap: landAnalysis.buildLandMap,
     buildSlaveToMasterMap: landAnalysis.buildSlaveToMasterMap,
     getDisplayLandContext: landAnalysis.getDisplayLandContext,

--- a/core/src/services/farm/land-analysis.ts
+++ b/core/src/services/farm/land-analysis.ts
@@ -23,7 +23,7 @@ function int64String(value: any): string {
 }
 
 function getLeftInorcFertTimes(plant: any): number | null {
-    if (!plant || !Object.prototype.hasOwnProperty.call(plant, 'left_inorc_fert_times')) {
+    if (!plant || !Object.hasOwn(plant, 'left_inorc_fert_times')) {
         return null;
     }
     return toNum(plant.left_inorc_fert_times);
@@ -375,7 +375,7 @@ function getOrganicFertilizerTargetsFromLands(lands: any[]): number[] {
         if (currentPhase.phase === PlantPhase.DEAD) continue;
 
         // 服务端有该字段时，<=0 说明该地当前不能再施有机肥
-        if (Object.prototype.hasOwnProperty.call(plant, 'left_inorc_fert_times')) {
+        if (Object.hasOwn(plant, 'left_inorc_fert_times')) {
             const leftTimes = toNum(plant.left_inorc_fert_times);
             if (leftTimes <= 0) continue;
         }
@@ -412,7 +412,7 @@ function getFastMatureLands(lands: any[], thresholdSec: number = 300): number[] 
         const timeToMature = matureBeginTime - nowSec;
 
         if (timeToMature <= threshold && timeToMature >= 0) {
-            if (Object.prototype.hasOwnProperty.call(plant, 'left_inorc_fert_times')) {
+            if (Object.hasOwn(plant, 'left_inorc_fert_times')) {
                 const leftTimes = toNum(plant.left_inorc_fert_times);
                 if (leftTimes <= 0) continue;
             }
@@ -930,6 +930,7 @@ module.exports = {
     buildSlaveToMasterMap,
     isOccupiedSlaveLandWithMap,
     summarizeLandDetails,
+    ALL_FERTILIZER_LAND_TYPES,
     getLandTypeByLevel,
     normalizeFertilizerLandTypes,
     filterLandIdsByTypes,

--- a/core/src/services/farm/land-analysis.ts
+++ b/core/src/services/farm/land-analysis.ts
@@ -22,6 +22,13 @@ function int64String(value: any): string {
     return /^-?\d+$/.test(text) ? text : '0';
 }
 
+function getLeftInorcFertTimes(plant: any): number | null {
+    if (!plant || !Object.prototype.hasOwnProperty.call(plant, 'left_inorc_fert_times')) {
+        return null;
+    }
+    return toNum(plant.left_inorc_fert_times);
+}
+
 function normalizePositiveId(value: any): string {
     const text = int64String(value);
     return /^\d+$/.test(text) && text !== '0' ? text : '';
@@ -234,6 +241,7 @@ function buildLandDetail(land: any, options: { friendMode?: boolean; landsMap?: 
         isMutated: false,
         interactionEffects: [],
         protocolField40: null,
+        leftInorcFertTimes: null,
     };
     if (!base.unlocked) {
         return {
@@ -315,6 +323,7 @@ function buildLandDetail(land: any, options: { friendMode?: boolean; landsMap?: 
         isMutated: mutantConfigIds.length > 0,
         interactionEffects: getPlantInteractionEffects(plant),
         protocolField40: protocolField40.length > 0 ? protocolField40 : null,
+        leftInorcFertTimes: getLeftInorcFertTimes(plant),
     };
 }
 

--- a/core/src/services/farm/planting.ts
+++ b/core/src/services/farm/planting.ts
@@ -13,7 +13,7 @@ const { getPlantRankings } = require('../analytics');
 const { recordOperation } = require('../stats');
 const { getBagSeeds } = require('../warehouse');
 const { getCareerInfoOrNull } = require('../career');
-const { getAllLands, buyGoods, removePlant } = require('./api');
+const { getAllLands, buyGoods, removePlant, fertilizeOne } = require('./api');
 const {
     buildLandDetail,
     analyzeLands,
@@ -44,6 +44,7 @@ interface PlantSeedsResult {
 }
 
 const NORMAL_FERTILIZER_ID: number = 1011;
+const ORGANIC_FERTILIZER_ID: number = 1012;
 const ALL_FERTILIZER_LAND_TYPES: string[] = ['gold', 'black', 'red', 'normal'];
 
 function confirmsPlantedFootprint(
@@ -871,6 +872,56 @@ async function runFertilizerByConfig(plantedLands: any[] = [], options: { skipNo
     return { normal: fertilizedNormal, organic: fertilizedOrganic };
 }
 
+async function fertilizeOwnLand(landIdInput: unknown, fertilizerTypeInput: unknown): Promise<any> {
+    const landId = toNum(landIdInput);
+    if (!landId || landId <= 0) {
+        throw new Error('地块编号无效');
+    }
+
+    const fertilizerType = String(fertilizerTypeInput || '').trim().toLowerCase();
+    if (fertilizerType !== 'normal' && fertilizerType !== 'organic') {
+        throw new Error('化肥类型必须是 normal 或 organic');
+    }
+
+    const fertilizerId = fertilizerType === 'organic' ? ORGANIC_FERTILIZER_ID : NORMAL_FERTILIZER_ID;
+    const typeName = fertilizerType === 'organic' ? '有机化肥' : '普通化肥';
+    let reply: any;
+    try {
+        reply = await fertilizeOne(landId, fertilizerId);
+    }
+    catch (error: any) {
+        const message = String(error?.errorMessage || '').trim()
+            || String(error?.message || '').replace(/^[\s\S]*错误:\s*code=\d+\s+/, '').trim()
+            || `${typeName}使用失败`;
+        throw new Error(message);
+    }
+    const replyLands = Array.isArray(reply && reply.land) ? reply.land : [];
+    const updatedRaw = replyLands.find((land: any) => toNum(land?.id) === landId) || replyLands[0] || null;
+    const nowSec = getServerTimeSec();
+    const landsMap = updatedRaw ? buildLandMap([updatedRaw]) : new Map();
+    const updatedLand = updatedRaw
+        ? buildLandDetail(updatedRaw, { friendMode: false, landsMap, nowSec })
+        : null;
+    const fertilizerRemainingSec = toNum(reply && reply.fertilizer);
+
+    recordOperation('fertilize', 1);
+    log('施肥', `手动施肥：第 ${landId} 块地已施${typeName}`, {
+        module: 'farm',
+        event: '手动施肥',
+        result: 'ok',
+        type: fertilizerType,
+        landId,
+        remainingSec: fertilizerRemainingSec,
+    });
+
+    return {
+        landId,
+        fertilizerType,
+        fertilizerRemainingSec,
+        updatedLand,
+    };
+}
+
 module.exports = {
     getPlantSizeBySeedId,
     plantSeeds,
@@ -883,4 +934,5 @@ module.exports = {
     autoPlantEmptyLands,
     plantFromShop,
     runFertilizerByConfig,
+    fertilizeOwnLand,
 };

--- a/core/src/services/farm/planting.ts
+++ b/core/src/services/farm/planting.ts
@@ -5,7 +5,7 @@ export {};
 
 const protobuf = require('protobufjs');
 const { getPlantNameBySeedId, formatGrowTime, getPlantGrowTime, getAllSeeds, getPlantBySeedId } = require('../../config/gameConfig');
-const { getPreferredSeed, getAutomation, getPlantingStrategy, getBagSeedPriority, getBagSeedFallbackStrategy } = require('../../models/store');
+const { getPreferredSeed, getAutomation, getPlantingStrategy, getBagSeedPriority, getBagSeedLandTypes, getBagSeedFallbackStrategy } = require('../../models/store');
 const { getUserState, getWsErrorState, sendMsgAsync } = require('../../utils/network');
 const { toNum, getServerTimeSec, log, logWarn, sleep } = require('../../utils/utils');
 const { types } = require('../../utils/proto');
@@ -15,6 +15,7 @@ const { getBagSeeds } = require('../warehouse');
 const { getCareerInfoOrNull } = require('../career');
 const { getAllLands, buyGoods, removePlant, fertilizeOne } = require('./api');
 const {
+    ALL_FERTILIZER_LAND_TYPES,
     buildLandDetail,
     analyzeLands,
     buildLandMap,
@@ -45,7 +46,6 @@ interface PlantSeedsResult {
 
 const NORMAL_FERTILIZER_ID: number = 1011;
 const ORGANIC_FERTILIZER_ID: number = 1012;
-const ALL_FERTILIZER_LAND_TYPES: string[] = ['gold', 'black', 'red', 'normal'];
 
 function confirmsPlantedFootprint(
     expectedLandIds: Set<number>,
@@ -210,7 +210,19 @@ function sortBagSeedsForPlanting(bagSeeds: any[], priorityList: any[] | undefine
     });
 }
 
-async function plantFromBagSeeds(landsToPlant: any[]): Promise<{
+/**
+ * 该种子允许种植的土地类型；null 表示不限制。
+ * 缺配置、空数组、勾满全部类型三者等价于不限制。
+ */
+function resolveSeedLandTypes(bagSeedLandTypes: any, seedId: any): string[] | null {
+    const raw = bagSeedLandTypes && bagSeedLandTypes[String(toNum(seedId))];
+    if (!Array.isArray(raw)) return null;
+    const types: string[] = normalizeFertilizerLandTypes(raw);
+    if (types.length === 0 || types.length === ALL_FERTILIZER_LAND_TYPES.length) return null;
+    return types;
+}
+
+async function plantFromBagSeeds(landsToPlant: any[], landTypeById?: Map<number, string>): Promise<{
     remainingLandIds: number[];
     fallbackAllowed: boolean;
     plantedLandIds: number[];
@@ -226,6 +238,8 @@ async function plantFromBagSeeds(landsToPlant: any[]): Promise<{
     const bagSeeds = await getBagSeeds();
     const state = getUserState();
     const priorityList = getBagSeedPriority();
+    const bagSeedLandTypes = getBagSeedLandTypes() || {};
+    const landTypeAvailable = !!(landTypeById && landTypeById.size > 0);
     const allBagSeeds = (Array.isArray(bagSeeds) ? bagSeeds : []);
     
     const stateLevel = toNum(state && state.level);
@@ -235,6 +249,8 @@ async function plantFromBagSeeds(landsToPlant: any[]): Promise<{
         count: toNum(seed && seed.count),
         requiredLevel: toNum(seed && seed.requiredLevel),
         plantSize: Math.max(1, toNum(seed && seed.plantSize) || getPlantSizeBySeedId(seed && seed.seedId)),
+        // 拿不到土地类型时按不限制处理，避免整轮种不下去。
+        landTypes: landTypeAvailable ? resolveSeedLandTypes(bagSeedLandTypes, seed && seed.seedId) : null,
         stateLevel,
     }));
     log('种植', `背包种子原始: ${filteredForLevelAndCount.map((s: any) => `${s.name}(${s.seedId})x${s.count},lv${s.requiredLevel},size${s.plantSize}`).join('; ')}`, {
@@ -274,11 +290,20 @@ async function plantFromBagSeeds(landsToPlant: any[]): Promise<{
             module: 'farm', event: '种植种子', result: 'bag_seed_skip', strategy: 'bag_priority', skipped: skippedSeeds,
         });
     }
-if (usableSeeds.length > 0) {
-        const orderedSeeds = usableSeeds.map((seed: any, index: number) => `${index + 1}.${seed.name}(${seed.seedId})x${toNum(seed && seed.count)}`).join(' -> ');
+    // 有土地限制的种子先种，否则不限制的种子会把受限种子唯一能用的地块占光。
+    const plantingOrder: any[] = [
+        ...usableSeeds.filter((seed: any) => !!seed.landTypes),
+        ...usableSeeds.filter((seed: any) => !seed.landTypes),
+    ];
+
+    if (plantingOrder.length > 0) {
+        const orderedSeeds = plantingOrder.map((seed: any, index: number) => {
+            const scope = seed.landTypes ? `[仅${formatFertilizerLandTypes(seed.landTypes).join('/')}]` : '';
+            return `${index + 1}.${seed.name}(${seed.seedId})x${toNum(seed && seed.count)}${scope}`;
+        }).join(' -> ');
         log('种植', `背包种子执行顺序: ${orderedSeeds}`, {
             module: 'farm', event: '种植种子', result: 'bag_priority_order', strategy: 'bag_priority',
-            priority: priorityList, seedIds: usableSeeds.map((seed: any) => seed.seedId),
+            priority: priorityList, seedIds: plantingOrder.map((seed: any) => seed.seedId),
         });
     }
 
@@ -296,21 +321,31 @@ if (usableSeeds.length > 0) {
     const plantedLandIds: number[] = [];
     const usedSeedLogs: string[] = [];
 
-    for (const seed of usableSeeds) {
+    for (const seed of plantingOrder) {
         if (remainingLandIds.length === 0 || !fallbackAllowed) break;
 
         const plantSize = Math.max(1, toNum(seed && seed.plantSize) || getPlantSizeBySeedId(seed.seedId));
-        const allLayouts: PlantingLayout[] = buildPlantingLayouts(remainingLandIds, plantSize);
+        // 受限种子只在命中类型的空地上装箱；未命中的空地留给后续种子或第二优先策略。
+        const allowedLandIds: number[] = seed.landTypes
+            ? filterLandIdsByTypes(remainingLandIds, landTypeById, seed.landTypes)
+            : remainingLandIds;
+        const allLayouts: PlantingLayout[] = buildPlantingLayouts(allowedLandIds, plantSize);
         const layouts: PlantingLayout[] = selectNonOverlappingLayouts(allLayouts, toNum(seed.count));
-        log('种植', `背包种子 ${seed.name}(${seed.seedId}) size=${plantSize} count=${seed.count} 剩余=${remainingLandIds.length} allLayouts=${allLayouts.length} selected=${layouts.length}`, {
+        const scopeLog = seed.landTypes ? ` 限${formatFertilizerLandTypes(seed.landTypes).join('/')}=${allowedLandIds.length}` : '';
+        log('种植', `背包种子 ${seed.name}(${seed.seedId}) size=${plantSize} count=${seed.count} 剩余=${remainingLandIds.length}${scopeLog} allLayouts=${allLayouts.length} selected=${layouts.length}`, {
             module: 'farm', event: '种植种子', result: 'layout_check', strategy: 'bag_priority',
             seedId: seed.seedId, plantSize, count: seed.count, emptyCount: remainingLandIds.length,
+            landTypes: seed.landTypes || null, allowedCount: allowedLandIds.length,
             allLayouts: allLayouts.length, selectedLayouts: layouts.length, remainingLandIds,
         });
         if (layouts.length === 0) {
-            log('种植', `背包种子 ${seed.name} 无合法${plantSize}x${plantSize} 布局，已跳过`, {
+            const reason = seed.landTypes && allowedLandIds.length === 0
+                ? `无${formatFertilizerLandTypes(seed.landTypes).join('/')}空地`
+                : `无合法${plantSize}x${plantSize} 布局`;
+            log('种植', `背包种子 ${seed.name} ${reason}，已跳过`, {
                 module: 'farm', event: '种植种子', result: 'skip_no_layout', strategy: 'bag_priority',
-                seedId: seed.seedId, plantSize, emptyCount: remainingLandIds.length
+                seedId: seed.seedId, plantSize, emptyCount: remainingLandIds.length,
+                landTypes: seed.landTypes || null, allowedCount: allowedLandIds.length,
             });
             continue;
         }
@@ -511,8 +546,8 @@ async function getAvailableSeeds(): Promise<any[]> {
         }));
     }
     return list.sort((a: any, b: any) => {
-        const av = (a.requiredLevel === null || a.requiredLevel === undefined) ? 9999 : a.requiredLevel;
-        const bv = (b.requiredLevel === null || b.requiredLevel === undefined) ? 9999 : b.requiredLevel;
+        const av = a.requiredLevel ?? 9999;
+        const bv = b.requiredLevel ?? 9999;
         return av - bv;
     });
 }
@@ -544,9 +579,44 @@ async function getLandsDetail(): Promise<{ lands: any[]; summary: any; career: a
     };
 }
 
+/**
+ * 解析 landId -> 土地类型。仅在配置了土地限制时才解析，未配置的账号不额外请求土地。
+ * 解析不出来时返回 undefined，调用方按不限制处理。
+ */
+async function resolveLandTypeMapForBagSeeds(knownLands: any[]): Promise<Map<number, string> | undefined> {
+    if (Object.keys(getBagSeedLandTypes() || {}).length === 0) return undefined;
+
+    let lands: any[] = Array.isArray(knownLands) ? knownLands : [];
+    if (lands.length === 0) {
+        try {
+            const latest = await getAllLands();
+            lands = Array.isArray(latest && latest.lands) ? latest.lands : [];
+        } catch (e: any) {
+            logWarn('种植', `获取土地类型失败，本轮忽略背包种子的土地限制: ${e.message}`, {
+                module: 'farm', event: '种植种子', result: 'land_type_error', strategy: 'bag_priority',
+            });
+            return undefined;
+        }
+    }
+
+    const landTypeById = new Map<number, string>();
+    for (const land of lands) {
+        const landId = toNum(land && land.id);
+        if (!landId) continue;
+        landTypeById.set(landId, getLandTypeByLevel(land.level));
+    }
+    if (landTypeById.size === 0) {
+        logWarn('种植', '无法确认土地类型，本轮忽略背包种子的土地限制', {
+            module: 'farm', event: '种植种子', result: 'land_type_empty', strategy: 'bag_priority',
+        });
+    }
+    return landTypeById;
+}
+
 async function autoPlantEmptyLands(deadLandIds: number[], emptyLandIds: number[]): Promise<any> {
     let landsToPlant: number[] = [...new Set<number>((Array.isArray(emptyLandIds) ? emptyLandIds : [])
         .map((id: any) => toNum(id)).filter((id: number) => id > 0))];
+    let latestLands: any[] = [];
     const state = getUserState();
 
     // 1. 铲除枯死/收获残留植物（一键操作），随后以服务端最新状态确认可用土地。
@@ -558,7 +628,8 @@ async function autoPlantEmptyLands(deadLandIds: number[], emptyLandIds: number[]
             });
             try {
                 const latest = await getAllLands();
-                landsToPlant = analyzeLands(Array.isArray(latest && latest.lands) ? latest.lands : []).empty;
+                latestLands = Array.isArray(latest && latest.lands) ? latest.lands : [];
+                landsToPlant = analyzeLands(latestLands).empty;
             } catch (e: any) {
                 logWarn('铲除', `铲除后确认土地失败，保留原有空地且不使用枯死地块: ${e.message}`, {
                     module: 'farm', event: '铲除植物', result: 'confirm_error'
@@ -579,7 +650,8 @@ async function autoPlantEmptyLands(deadLandIds: number[], emptyLandIds: number[]
     if (accountStrategy === 'bag_priority') {
         let bagResult: any;
         try {
-            bagResult = await plantFromBagSeeds(landsToPlant);
+            const landTypeById = await resolveLandTypeMapForBagSeeds(latestLands);
+            bagResult = await plantFromBagSeeds(landsToPlant, landTypeById);
         } catch (e: any) {
             logWarn('种植', `读取背包种子失败，本轮跳过第二优先策略以避免误购: ${e.message}`, {
                 module: 'farm',
@@ -927,6 +999,7 @@ module.exports = {
     plantSeeds,
     getPlantingStrategyLabel,
     sortBagSeedsForPlanting,
+    resolveSeedLandTypes,
     plantFromBagSeeds,
     findBestSeed,
     getAvailableSeeds,

--- a/core/src/services/stats.ts
+++ b/core/src/services/stats.ts
@@ -250,10 +250,10 @@ function getStats(statusData: any, userState: any, connected: boolean, limits: a
     const statusObj: any = (statusData && typeof statusData === 'object') ? statusData : {};
     const userObj: any = (userState && typeof userState === 'object') ? userState : {};
 
-    const rawGold: any = (userObj.gold !== null && userObj.gold !== undefined) ? userObj.gold : statusObj.gold;
-    const rawExp: any = (userObj.exp !== null && userObj.exp !== undefined) ? userObj.exp : statusObj.exp;
-    const rawCoupon: any = (userObj.coupon !== null && userObj.coupon !== undefined) ? userObj.coupon : statusObj.coupon;
-    const rawGoldBean: any = (userObj.goldBean !== null && userObj.goldBean !== undefined) ? userObj.goldBean : statusObj.goldBean;
+    const rawGold: any = userObj.gold ?? statusObj.gold;
+    const rawExp: any = userObj.exp ?? statusObj.exp;
+    const rawCoupon: any = userObj.coupon ?? statusObj.coupon;
+    const rawGoldBean: any = userObj.goldBean ?? statusObj.goldBean;
     const currentGold: number = Number.isFinite(Number(rawGold)) ? Number(rawGold) : 0;
     const currentExp: number = Number.isFinite(Number(rawExp)) ? Number(rawExp) : 0;
     const currentCoupon: number = Number.isFinite(Number(rawCoupon)) ? Number(rawCoupon) : 0;

--- a/core/src/services/wx-login/service.ts
+++ b/core/src/services/wx-login/service.ts
@@ -27,7 +27,7 @@ interface HttpResult {
 }
 
 function cookieHeader(cookies: Map<string, string>): string {
-    return [...cookies].map(([name, value]) => `${name}=${value}`).join('; ');
+    return Array.from(cookies, ([name, value]) => `${name}=${value}`).join('; ');
 }
 
 function storeCookies(cookies: Map<string, string>, headers: Headers): void {

--- a/core/src/types/config.ts
+++ b/core/src/types/config.ts
@@ -41,6 +41,7 @@ export interface AutomationConfig {
   fertilizer_land_types: FertilizerLandType[];
   fertilizer_smart_seconds: number;
   skip_own_weed_bug: boolean;
+  show_manual_fertilizer: boolean;
 }
 
 export interface IntervalConfig {

--- a/core/src/types/config.ts
+++ b/core/src/types/config.ts
@@ -82,6 +82,8 @@ export interface AccountConfig {
   fertilizerBuyNormalThresholdHours: number;
   fertilizerBuyCheckIntervalMinutes: number;
   bagSeedPriority: number[];
+  /** seedId -> 允许种植的土地类型。缺 key 视为不限制。 */
+  bagSeedLandTypes: Record<string, FertilizerLandType[]>;
   bagSeedFallbackStrategy: BagSeedFallbackStrategy;
   autoAcceptFriendMinLevel: number;
   autoAcceptRequireOwnLevel: boolean;

--- a/core/src/utils/network.ts
+++ b/core/src/utils/network.ts
@@ -241,7 +241,7 @@ function clearWsErrorState(): void {
 }
 
 function hasOwn(obj: any, key: string): boolean {
-    return !!obj && Object.prototype.hasOwnProperty.call(obj, key);
+    return !!obj && Object.hasOwn(obj, key);
 }
 
 // 登录后获取用户设置

--- a/core/tests/network-keepalive.test.js
+++ b/core/tests/network-keepalive.test.js
@@ -33,7 +33,7 @@ test('legacy defaults migrate while explicit custom client versions survive', ()
 
 test('ordinary gateway tokens retain the official random format', () => {
     for (let index = 0; index < 256; index += 1) {
-        assert.match(createGatewayToken(), /^[A-Za-z0-9]{64,127}=$/);
+        assert.match(createGatewayToken(), /^[A-Z0-9]{64,127}=$/i);
     }
 });
 
@@ -43,7 +43,7 @@ test('the TSDK initialization credential is consumed exactly once', () => {
 
     assert.equal(provider.stageInitToken(initToken), 152);
     assert.equal(provider.next(), initToken);
-    assert.match(provider.next(), /^[A-Za-z0-9]{64,127}=$/);
+    assert.match(provider.next(), /^[A-Z0-9]{64,127}=$/i);
 
     provider.stageInitToken(initToken);
     provider.clear();

--- a/web/src/components/FarmPanel.vue
+++ b/web/src/components/FarmPanel.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { FertilizerType } from '@/stores/farm'
 import type { FriendInteractionItemDto, FriendInteractionResultDto } from '@/stores/friend'
 import { useIntervalFn } from '@vueuse/core'
 import { NButton } from 'naive-ui'
@@ -32,6 +33,8 @@ const {
   dogSkillGiftStatusLoading,
   dogSkillGiftClaiming,
   dogSkillGiftError,
+  fertilizePending,
+  fertilizeError,
 } = storeToRefs(farmStore)
 const { currentAccountId, currentAccount } = storeToRefs(accountStore)
 const { status } = storeToRefs(statusStore)
@@ -47,6 +50,7 @@ const currentAccountRunning = computed(() => (
 ))
 
 const operating = ref(false)
+const fertilizingLandId = ref<number | null>(null)
 const manualRefreshing = ref(false)
 const refreshIconClass = 'i-carbon-renew'
 const confirmVisible = ref(false)
@@ -206,6 +210,58 @@ function interactionFailures() {
   return results.filter(result => !result.ok)
 }
 
+function isFertilizeCandidate(land: any) {
+  return !!land?.unlocked
+    && !land?.occupiedByMaster
+    && String(land?.status || '') === 'growing'
+    && Number(land?.matureInSec) > 0
+}
+
+function canOrganicFertilize(land: any) {
+  const left = land?.leftInorcFertTimes
+  return left == null || Number(left) > 0
+}
+
+function organicFertilizerLabel(land: any) {
+  const left = land?.leftInorcFertTimes
+  if (left != null && Number(left) <= 0)
+    return '已无法再施有机肥'
+  return ''
+}
+
+function formatFertilizerRemaining(sec: number) {
+  const remaining = Number(sec) || 0
+  if (remaining <= 0)
+    return ''
+  return `剩余 ${(remaining / 3600).toFixed(1)}h`
+}
+
+async function handleFertilize(land: any, fertilizerType: FertilizerType) {
+  if (!currentAccountId.value || fertilizePending.value || !isFertilizeCandidate(land))
+    return
+  if (fertilizerType === 'organic' && !canOrganicFertilize(land)) {
+    toast.info('该地块已无法再施有机肥')
+    return
+  }
+
+  const typeName = fertilizerType === 'organic' ? '有机化肥' : '普通化肥'
+  const landId = Number(land.id)
+  fertilizingLandId.value = landId
+  try {
+    const result = await farmStore.fertilizeLand(currentAccountId.value, landId, fertilizerType)
+    if (!result) {
+      toast.error(fertilizeError.value || `${typeName}使用失败`)
+      return
+    }
+    const remainingText = formatFertilizerRemaining(Number(result.fertilizerRemainingSec || 0))
+    toast.success(remainingText ? `已施${typeName}，${remainingText}` : `已施${typeName}`)
+  }
+  finally {
+    if (fertilizingLandId.value === landId)
+      fertilizingLandId.value = null
+  }
+}
+
 function requestUseInteractionItem() {
   const item = selectedInteractionItem.value
   if (!currentAccountId.value || !item || selectedInteractionIds(item.itemId).length === 0)
@@ -298,6 +354,7 @@ async function claimDogSkillGifts() {
 
 watch(currentAccountId, () => {
   farmStore.resetLandState()
+  fertilizingLandId.value = null
   selectedInteractionItemId.value = ''
   selectedInteractionLandIds.value = {}
   lastInteractionResults.value = {}
@@ -579,7 +636,13 @@ onUnmounted(() => {
               :selected="isInteractionLandSelected(land)"
               :selection-disabled="isInteractionLandDisabled(land)"
               :selection-label="interactionLandSelectionLabel(land)"
+              :show-fertilizer-actions="isFertilizeCandidate(land)"
+              :fertilizer-pending="fertilizePending && fertilizingLandId === land.id"
+              :normal-fertilizer-disabled="fertilizePending"
+              :organic-fertilizer-disabled="fertilizePending || !canOrganicFertilize(land)"
+              :organic-fertilizer-label="organicFertilizerLabel(land)"
               @select="toggleInteractionLand(land)"
+              @fertilize="handleFertilize"
             />
           </div>
         </div>

--- a/web/src/components/FarmPanel.vue
+++ b/web/src/components/FarmPanel.vue
@@ -10,11 +10,13 @@ import ConfirmModal from '@/components/ConfirmModal.vue'
 import LandCard from '@/components/LandCard.vue'
 import { useAccountStore } from '@/stores/account'
 import { useFarmStore } from '@/stores/farm'
+import { useSettingStore } from '@/stores/setting'
 import { useStatusStore } from '@/stores/status'
 import { useToastStore } from '@/stores/toast'
 
 const farmStore = useFarmStore()
 const accountStore = useAccountStore()
+const settingStore = useSettingStore()
 const statusStore = useStatusStore()
 const toast = useToastStore()
 const {
@@ -37,6 +39,7 @@ const {
   fertilizeError,
 } = storeToRefs(farmStore)
 const { currentAccountId, currentAccount } = storeToRefs(accountStore)
+const { settings } = storeToRefs(settingStore)
 const { status } = storeToRefs(statusStore)
 
 const currentAccountConnected = computed(() => {
@@ -69,6 +72,8 @@ const interactionConfirmMessage = ref('')
 const selectedInteractionItem = computed<FriendInteractionItemDto | null>(() => (
   interactionItems.value.find(item => String(item.itemId) === selectedInteractionItemId.value) || null
 ))
+
+const showManualFertilizerButtons = computed(() => settings.value.automation?.show_manual_fertilizer !== false)
 
 async function executeOperate() {
   if (!currentAccountId.value || !confirmConfig.value.opType)
@@ -312,6 +317,7 @@ async function refreshFarmData() {
   await Promise.all([
     farmStore.fetchLands(accountId),
     farmStore.fetchInteractionItems(accountId),
+    settingStore.fetchSettings(accountId),
   ])
 }
 
@@ -326,6 +332,7 @@ async function refreshWithDogGifts() {
       farmStore.fetchLands(accountId),
       farmStore.fetchInteractionItems(accountId),
       farmStore.fetchDogSkillGiftStatus(accountId),
+      settingStore.fetchSettings(accountId),
     ])
   }
   finally {
@@ -636,7 +643,7 @@ onUnmounted(() => {
               :selected="isInteractionLandSelected(land)"
               :selection-disabled="isInteractionLandDisabled(land)"
               :selection-label="interactionLandSelectionLabel(land)"
-              :show-fertilizer-actions="isFertilizeCandidate(land)"
+              :show-fertilizer-actions="showManualFertilizerButtons && isFertilizeCandidate(land)"
               :fertilizer-pending="fertilizePending && fertilizingLandId === land.id"
               :normal-fertilizer-disabled="fertilizePending"
               :organic-fertilizer-disabled="fertilizePending || !canOrganicFertilize(land)"

--- a/web/src/components/LandCard.vue
+++ b/web/src/components/LandCard.vue
@@ -7,15 +7,26 @@ const props = withDefaults(defineProps<{
   selected?: boolean
   selectionDisabled?: boolean
   selectionLabel?: string
+  showFertilizerActions?: boolean
+  fertilizerPending?: boolean
+  normalFertilizerDisabled?: boolean
+  organicFertilizerDisabled?: boolean
+  organicFertilizerLabel?: string
 }>(), {
   selectable: false,
   selected: false,
   selectionDisabled: false,
   selectionLabel: '',
+  showFertilizerActions: false,
+  fertilizerPending: false,
+  normalFertilizerDisabled: false,
+  organicFertilizerDisabled: false,
+  organicFertilizerLabel: '',
 })
 
 const emit = defineEmits<{
   select: [land: any]
+  fertilize: [land: any, fertilizerType: 'normal' | 'organic']
 }>()
 
 const land = computed(() => props.land)
@@ -154,6 +165,24 @@ function activateSelection() {
   if (props.selectable && !props.selectionDisabled)
     emit('select', props.land)
 }
+
+function requestFertilize(event: Event, fertilizerType: 'normal' | 'organic') {
+  event.stopPropagation()
+  if (props.fertilizerPending)
+    return
+  if (fertilizerType === 'normal' && props.normalFertilizerDisabled)
+    return
+  if (fertilizerType === 'organic' && props.organicFertilizerDisabled)
+    return
+  emit('fertilize', props.land, fertilizerType)
+}
+
+const organicRemainingText = computed(() => {
+  const left = land.value?.leftInorcFertTimes
+  if (left == null || Number.isNaN(Number(left)))
+    return ''
+  return `有机剩 ${Math.max(0, Number(left))}`
+})
 
 function interactionEffectBadges(land: any) {
   const effects = Array.isArray(land?.interactionEffects) ? land.interactionEffects : []
@@ -372,6 +401,37 @@ function mutantIconUrl(icon: string) {
       >
         <span class="i-carbon-wheat" /> 成熟不可偷
       </span>
+      <span
+        v-if="organicRemainingText"
+        class="inline-flex items-center gap-0.5 rounded-full bg-lime-100 px-1.5 py-0.5 text-[10px] text-lime-800 font-bold dark:bg-lime-900/40 dark:text-lime-300"
+      >
+        <span class="i-carbon-chemistry" /> {{ organicRemainingText }}
+      </span>
+    </div>
+
+    <div v-if="showFertilizerActions" class="fertilizer-actions mt-2 w-full" @click.stop>
+      <button
+        type="button"
+        class="fertilizer-action fertilizer-action--normal"
+        :disabled="fertilizerPending || normalFertilizerDisabled"
+        title="对该地块施一次普通化肥"
+        @click="requestFertilize($event, 'normal')"
+      >
+        <span v-if="fertilizerPending" class="i-svg-spinners-90-ring-with-bg" />
+        <span v-else class="i-carbon-chemistry" />
+        普通
+      </button>
+      <button
+        type="button"
+        class="fertilizer-action fertilizer-action--organic"
+        :disabled="fertilizerPending || organicFertilizerDisabled"
+        :title="organicFertilizerDisabled ? (organicFertilizerLabel || '已无法再施有机肥') : '对该地块施一次有机化肥'"
+        @click="requestFertilize($event, 'organic')"
+      >
+        <span v-if="fertilizerPending" class="i-svg-spinners-90-ring-with-bg" />
+        <span v-else class="i-carbon-sprout" />
+        有机
+      </button>
     </div>
   </div>
 </template>
@@ -898,5 +958,55 @@ function mutantIconUrl(icon: string) {
 .badge-bug,
 .badge-harvest {
   animation: none;
+}
+
+.fertilizer-actions {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px;
+}
+
+.fertilizer-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  min-height: 26px;
+  padding: 0 6px;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.fertilizer-action--normal {
+  color: #5b4630;
+  background: #fff4d6;
+  border-color: #ead28a;
+}
+
+.fertilizer-action--organic {
+  color: #245f4b;
+  background: #e8f7ea;
+  border-color: #b5dcb8;
+}
+
+.fertilizer-action:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+:global(.dark) .fertilizer-action--normal {
+  color: #fde68a;
+  background: rgba(120, 90, 20, 0.35);
+  border-color: rgba(234, 210, 138, 0.4);
+}
+
+:global(.dark) .fertilizer-action--organic {
+  color: #bbf7d0;
+  background: rgba(20, 80, 50, 0.35);
+  border-color: rgba(181, 220, 184, 0.35);
 }
 </style>

--- a/web/src/components/LandCard.vue
+++ b/web/src/components/LandCard.vue
@@ -402,7 +402,7 @@ function mutantIconUrl(icon: string) {
         <span class="i-carbon-wheat" /> 成熟不可偷
       </span>
       <span
-        v-if="organicRemainingText"
+        v-if="showFertilizerActions && organicRemainingText"
         class="inline-flex items-center gap-0.5 rounded-full bg-lime-100 px-1.5 py-0.5 text-[10px] text-lime-800 font-bold dark:bg-lime-900/40 dark:text-lime-300"
       >
         <span class="i-carbon-chemistry" /> {{ organicRemainingText }}

--- a/web/src/components/settings/AutomationSettingsForm.vue
+++ b/web/src/components/settings/AutomationSettingsForm.vue
@@ -59,6 +59,7 @@ const settings = defineModel<AutomationSettingsFormModel>({ required: true })
         <BaseSwitch v-model="settings.automation.fertilizer_buy_organic" label="自动购买有机化肥" />
         <BaseSwitch v-model="settings.automation.fertilizer_buy_normal" label="自动购买无机化肥" />
         <BaseSwitch v-model="settings.automation.fertilizer_multi_season" label="多季补肥" />
+        <BaseSwitch v-model="settings.automation.show_manual_fertilizer" label="显示地块手动施肥按钮" />
       </div>
 
       <div v-if="settings.automation.fertilizer_buy_organic || settings.automation.fertilizer_buy_normal" class="mt-3 rounded bg-green-50 p-3 text-sm space-y-3 dark:bg-green-900/20">

--- a/web/src/components/settings/BagSeedPriorityItem.vue
+++ b/web/src/components/settings/BagSeedPriorityItem.vue
@@ -1,0 +1,162 @@
+<script setup lang="ts">
+import { NButton, NCheckbox, NCheckboxGroup } from 'naive-ui'
+import { computed, ref, watch } from 'vue'
+
+export interface BagSeedPriorityItemSeed {
+  seedId: number
+  name: string
+  count: number
+  requiredLevel: number
+  plantSize: number
+  image?: string
+}
+
+const props = defineProps<{
+  seed: BagSeedPriorityItemSeed
+  index: number
+  landTypes?: string[]
+  landTypeOptions: Array<{ label: string, value: string }>
+  dragging: boolean
+  canMoveUp: boolean
+  canMoveDown: boolean
+}>()
+
+const emit = defineEmits<{
+  'moveUp': []
+  'moveDown': []
+  'update:landTypes': [value: string[]]
+  'dragStart': [event: DragEvent]
+  'dragEnd': []
+  'dragOver': [event: DragEvent]
+  'drop': [event: DragEvent]
+}>()
+
+const chevronUpIconClass = 'i-carbon-chevron-up'
+const chevronDownIconClass = 'i-carbon-chevron-down'
+
+const imageFailed = ref(false)
+const editing = ref(false)
+
+// 勾满全部类型和一个都不勾都等价于不限制，不在界面上保留这两种中间态。
+const restricted = computed(() => {
+  const count = props.landTypes?.length ?? 0
+  return count > 0 && count < props.landTypeOptions.length
+})
+
+const restrictionLabel = computed(() => {
+  if (!restricted.value)
+    return '不限制'
+  const labels = props.landTypeOptions
+    .filter(option => props.landTypes?.includes(option.value))
+    .map(option => option.label)
+  return `仅种 ${labels.join('、')}`
+})
+
+watch(restricted, (value) => {
+  if (!value)
+    editing.value = false
+})
+
+function handleLandTypesChange(value: (string | number)[]) {
+  const next = value.map(String)
+  emit('update:landTypes', next.length === props.landTypeOptions.length ? [] : next)
+}
+</script>
+
+<template>
+  <div
+    class="flex flex-col gap-2 border cartoon-card border-amber-200 rounded-xl bg-white px-3 py-2.5 dark:border-amber-700/50 dark:bg-gray-800"
+    :class="{ 'opacity-60 ring-2 ring-amber-400': dragging }"
+    draggable="true"
+    @dragstart="emit('dragStart', $event)"
+    @dragend="emit('dragEnd')"
+    @dragover.prevent="emit('dragOver', $event)"
+    @drop="emit('drop', $event)"
+  >
+    <div class="flex items-center gap-2">
+      <div class="h-9 w-9 flex shrink-0 items-center justify-center rounded-lg bg-amber-100 text-xs text-amber-700 font-bold dark:bg-amber-900/50 dark:text-amber-300">
+        {{ index + 1 }}
+      </div>
+      <div class="h-9 w-9 flex shrink-0 items-center justify-center overflow-hidden rounded-lg bg-amber-50 dark:bg-gray-700">
+        <img
+          v-if="seed.image && !imageFailed"
+          :src="seed.image"
+          :alt="`${seed.name}种子`"
+          class="h-9 w-9 object-contain"
+          loading="lazy"
+          @error="imageFailed = true"
+        >
+        <span v-else class="i-carbon-sprout text-lg text-amber-500 dark:text-amber-300" />
+      </div>
+      <div class="min-w-0 flex-1">
+        <div class="flex items-center gap-1.5">
+          <div class="truncate text-sm text-gray-800 font-semibold dark:text-gray-200">
+            {{ seed.name }}
+          </div>
+          <span class="shrink-0 rounded bg-amber-100 px-1.5 py-0.5 text-[10px] text-amber-700 font-semibold dark:bg-amber-900/50 dark:text-amber-300">
+            {{ seed.plantSize }}x{{ seed.plantSize }}
+          </span>
+        </div>
+        <div class="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
+          库存 {{ seed.count }} · {{ seed.requiredLevel }} 级 · ID {{ seed.seedId }}
+        </div>
+      </div>
+      <div class="flex shrink-0 flex-col gap-2">
+        <NButton
+          quaternary
+          circle
+          size="tiny"
+          :disabled="!canMoveUp"
+          title="上移"
+          aria-label="上移"
+          @click="emit('moveUp')"
+        >
+          <span :class="chevronUpIconClass" />
+        </NButton>
+        <NButton
+          quaternary
+          circle
+          size="tiny"
+          :disabled="!canMoveDown"
+          title="下移"
+          aria-label="下移"
+          @click="emit('moveDown')"
+        >
+          <span :class="chevronDownIconClass" />
+        </NButton>
+      </div>
+    </div>
+
+    <div class="border-t border-amber-100 pt-2 dark:border-amber-800/40" @mousedown.stop>
+      <button
+        type="button"
+        class="w-full flex items-center justify-between gap-2 rounded text-left text-xs"
+        :class="restricted ? 'text-amber-700 font-medium dark:text-amber-300' : 'text-gray-500 dark:text-gray-400'"
+        @click="editing = !editing"
+      >
+        <span class="truncate">土地：{{ restrictionLabel }}</span>
+        <span class="shrink-0" :class="editing ? chevronUpIconClass : chevronDownIconClass" />
+      </button>
+      <div v-if="editing" class="mt-2">
+        <NCheckboxGroup
+          :value="landTypes ?? []"
+          @update:value="handleLandTypesChange"
+        >
+          <div class="grid grid-cols-2 gap-1.5">
+            <NCheckbox
+              v-for="option in landTypeOptions"
+              :key="option.value"
+              :value="option.value"
+              size="small"
+            >
+              <span class="text-xs">{{ option.label }}</span>
+            </NCheckbox>
+          </div>
+        </NCheckboxGroup>
+        <p class="mt-1.5 text-[11px] text-gray-400 dark:text-gray-500">
+          不勾或勾满即为不限制。
+        </p>
+      </div>
+    </div>
+  </div>
+</template>

--- a/web/src/stores/farm.ts
+++ b/web/src/stores/farm.ts
@@ -8,6 +8,8 @@ import { defineStore } from 'pinia'
 import { ref } from 'vue'
 import api from '@/api'
 
+export type FertilizerType = 'normal' | 'organic'
+
 export interface Land {
   id: number
   plantName?: string
@@ -18,7 +20,23 @@ export interface Land {
   needWater?: boolean
   needWeed?: boolean
   needBug?: boolean
+  leftInorcFertTimes?: number | null
   [key: string]: any
+}
+
+export interface FertilizeLandResult {
+  landId: number
+  fertilizerType: FertilizerType
+  fertilizerRemainingSec: number
+  updatedLand?: Land | null
+}
+
+function userFacingFertilizeError(raw: unknown, fallback = '施肥失败') {
+  const text = String(raw || '').trim()
+  if (!text)
+    return fallback
+  const chinese = text.match(/错误:\s*code=\d+\s+(.+)$/)?.[1]
+  return (chinese || text).trim() || fallback
 }
 
 // UseReply.land 是刚成功操作后的权威快照，短期内不允许被随后的 AllLands 旧快照覆盖。
@@ -44,6 +62,8 @@ export const useFarmStore = defineStore('farm', () => {
   const dogSkillGiftClaiming = ref(false)
   const dogSkillGiftError = ref('')
   const dogSkillGiftAccountId = ref('')
+  const fertilizePending = ref(false)
+  const fertilizeError = ref('')
   let landRequestSequence = 0
   let interactionItemsRequestSequence = 0
   let dogSkillGiftRequestSequence = 0
@@ -170,6 +190,8 @@ export const useFarmStore = defineStore('farm', () => {
     loaded.value = false
     error.value = ''
     landOverlay = null
+    fertilizePending.value = false
+    fertilizeError.value = ''
     resetInteractionState()
     resetDogSkillGiftState()
   }
@@ -366,6 +388,39 @@ export const useFarmStore = defineStore('farm', () => {
       seeds.value = data.data || []
   }
 
+  async function fertilizeLand(accountId: string, landId: number, fertilizerType: FertilizerType) {
+    if (!accountId || !landId || fertilizePending.value)
+      return false
+    fertilizePending.value = true
+    fertilizeError.value = ''
+    try {
+      const res = await api.post('/api/farm/fertilize', {
+        landId,
+        fertilizerType,
+      }, {
+        headers: { 'x-account-id': accountId },
+        skipErrorToast: true,
+      } as any)
+      if (!res.data?.ok) {
+        fertilizeError.value = userFacingFertilizeError(res.data?.error)
+        return false
+      }
+      const result = res.data.data as FertilizeLandResult
+      if (result?.updatedLand)
+        recordLandUpdates([result.updatedLand])
+      else
+        await fetchLands(accountId)
+      return result
+    }
+    catch (cause: any) {
+      fertilizeError.value = userFacingFertilizeError(cause?.response?.data?.error || cause?.message)
+      return false
+    }
+    finally {
+      fertilizePending.value = false
+    }
+  }
+
   async function operate(accountId: string, opType: string) {
     if (!accountId)
       return
@@ -393,6 +448,8 @@ export const useFarmStore = defineStore('farm', () => {
     dogSkillGiftStatusLoading,
     dogSkillGiftClaiming,
     dogSkillGiftError,
+    fertilizePending,
+    fertilizeError,
     fetchLands,
     resetLandState,
     fetchSeeds,
@@ -404,5 +461,6 @@ export const useFarmStore = defineStore('farm', () => {
     fetchDogSkillGiftStatus,
     claimDogSkillGifts,
     resetDogSkillGiftState,
+    fertilizeLand,
   }
 })

--- a/web/src/stores/setting.ts
+++ b/web/src/stores/setting.ts
@@ -29,6 +29,7 @@ export interface AutomationConfig {
   mystery_shop_arrival_notify?: boolean
   mystery_shop_purchase_notify?: boolean
   skip_own_weed_bug?: boolean
+  show_manual_fertilizer?: boolean
 }
 
 export interface IntervalsConfig {

--- a/web/src/stores/setting.ts
+++ b/web/src/stores/setting.ts
@@ -70,6 +70,7 @@ export interface SettingsState {
   plantingStrategy: string
   preferredSeedId: number
   bagSeedPriority: number[]
+  bagSeedLandTypes: Record<string, string[]>
   bagSeedFallbackStrategy: string
   intervals: IntervalsConfig
   friendQuietHours: FriendQuietHoursConfig
@@ -95,6 +96,7 @@ type SaveableSettingsKey
   = | 'plantingStrategy'
     | 'preferredSeedId'
     | 'bagSeedPriority'
+    | 'bagSeedLandTypes'
     | 'bagSeedFallbackStrategy'
     | 'intervals'
     | 'friendQuietHours'
@@ -119,6 +121,7 @@ const SAVEABLE_SETTINGS_KEYS: SaveableSettingsKey[] = [
   'plantingStrategy',
   'preferredSeedId',
   'bagSeedPriority',
+  'bagSeedLandTypes',
   'bagSeedFallbackStrategy',
   'intervals',
   'friendQuietHours',
@@ -143,6 +146,7 @@ function createDefaultSettings(): SettingsState {
     plantingStrategy: 'max_exp',
     preferredSeedId: 0,
     bagSeedPriority: [],
+    bagSeedLandTypes: {},
     bagSeedFallbackStrategy: 'level',
     intervals: {},
     friendQuietHours: { enabled: false, start: '23:00', end: '07:00', continueFarm: true },
@@ -203,6 +207,7 @@ export const useSettingStore = defineStore('setting', () => {
       plantingStrategy: data.strategy || defaults.plantingStrategy,
       preferredSeedId: data.preferredSeed || defaults.preferredSeedId,
       bagSeedPriority: cloneValue(data.bagSeedPriority ?? defaults.bagSeedPriority),
+      bagSeedLandTypes: cloneValue(data.bagSeedLandTypes ?? defaults.bagSeedLandTypes),
       bagSeedFallbackStrategy: data.bagSeedFallbackStrategy ?? defaults.bagSeedFallbackStrategy,
       intervals: cloneValue(data.intervals || defaults.intervals),
       friendQuietHours: {

--- a/web/src/views/Settings.vue
+++ b/web/src/views/Settings.vue
@@ -817,6 +817,7 @@ const localAutomationSettings = ref({
     fertilizer_multi_season: false,
     fertilizer_land_types: [...allFertilizerLandTypes],
     fertilizer_smart_seconds: 300,
+    show_manual_fertilizer: true,
   },
   fertilizerBuyOrganicCount: 10,
   fertilizerBuyOrganicThresholdHours: 10,
@@ -868,6 +869,7 @@ function syncLocalAutomationSettings() {
         fertilizer_multi_season: false,
         fertilizer_land_types: [...allFertilizerLandTypes],
         fertilizer_smart_seconds: 300,
+        show_manual_fertilizer: true,
       }
     }
     else {
@@ -898,6 +900,7 @@ function syncLocalAutomationSettings() {
         fertilizer_multi_season: false,
         fertilizer_land_types: [...allFertilizerLandTypes],
         fertilizer_smart_seconds: 300,
+        show_manual_fertilizer: true,
       }
       localAutomationSettings.value.automation = {
         ...defaults,
@@ -907,6 +910,9 @@ function syncLocalAutomationSettings() {
     localAutomationSettings.value.automation.fertilizer_land_types = normalizeFertilizerLandTypes(localAutomationSettings.value.automation.fertilizer_land_types)
     if (localAutomationSettings.value.automation.fertilizer_smart_seconds === undefined) {
       localAutomationSettings.value.automation.fertilizer_smart_seconds = 300
+    }
+    if (localAutomationSettings.value.automation.show_manual_fertilizer === undefined) {
+      localAutomationSettings.value.automation.show_manual_fertilizer = true
     }
     localAutomationSettings.value.fertilizerBuyOrganicCount = settings.value.fertilizerBuyOrganicCount ?? 10
     localAutomationSettings.value.fertilizerBuyOrganicThresholdHours = settings.value.fertilizerBuyOrganicThresholdHours ?? 10

--- a/web/src/views/Settings.vue
+++ b/web/src/views/Settings.vue
@@ -7,6 +7,7 @@ import api from '@/api'
 import AccountModal from '@/components/AccountModal.vue'
 import ConfirmModal from '@/components/ConfirmModal.vue'
 import AutomationSettingsForm from '@/components/settings/AutomationSettingsForm.vue'
+import BagSeedPriorityItem from '@/components/settings/BagSeedPriorityItem.vue'
 import BaseButton from '@/components/ui/BaseButton.vue'
 import BaseInput from '@/components/ui/BaseInput.vue'
 import BaseSelect from '@/components/ui/BaseSelect.vue'
@@ -31,8 +32,6 @@ const initialTab = settingsTabKeys.includes(queryTab as SettingsTab)
   ? queryTab as SettingsTab
   : storedTab === 'user' ? 'system' : (storedTab as SettingsTab) || 'account'
 const activeTab = ref<SettingsTab>(initialTab)
-const chevronUpIconClass = 'i-carbon-chevron-up'
-const chevronDownIconClass = 'i-carbon-chevron-down'
 
 watch(activeTab, (newTab) => {
   localStorage.setItem('settings-active-tab', newTab)
@@ -250,6 +249,7 @@ const localStrategySettings = ref({
   plantingStrategy: 'max_exp',
   preferredSeedId: 0,
   bagSeedPriority: [] as number[],
+  bagSeedLandTypes: {} as Record<string, string[]>,
   bagSeedFallbackStrategy: 'level',
   stealDelaySeconds: 0,
   plantOrderRandom: false,
@@ -289,7 +289,6 @@ interface BagSeedItem {
 const bagSeeds = ref<BagSeedItem[]>([])
 const bagSeedsLoading = ref(false)
 const bagSeedsError = ref<string | null>(null)
-const bagSeedImageErrors = ref<Record<number, boolean>>({})
 const draggingBagSeedId = ref<number | null>(null)
 
 const visibleBagSeedIds = computed(() => bagSeeds.value.map(seed => seed.seedId))
@@ -344,6 +343,42 @@ const sortedBagSeeds = computed(() => {
   return normalizeVisibleBagSeedOrder()
     .map(seedId => itemMap.get(seedId))
     .filter((seed): seed is BagSeedItem => !!seed)
+})
+
+function setBagSeedLandTypes(seedId: number, types: string[]) {
+  const next = { ...localStrategySettings.value.bagSeedLandTypes }
+  // 按固定顺序收敛；不勾或勾满都等价于不限制，直接去掉该 seedId。
+  const normalized = fertilizerLandTypeOptions
+    .map(option => option.value)
+    .filter(value => types.includes(value))
+  if (normalized.length === 0 || normalized.length === fertilizerLandTypeOptions.length)
+    delete next[String(seedId)]
+  else
+    next[String(seedId)] = normalized
+  localStrategySettings.value.bagSeedLandTypes = next
+}
+
+// 设置页只列背包里现有的种子，缺货种子的限制仍保留，这里显式列出以免出现看不见的规则。
+const orphanRestrictedSeeds = computed(() => {
+  // 背包列表未加载时无法判断谁真的缺货，此时不显示，避免误清除已有限制。
+  if (bagSeeds.value.length === 0)
+    return []
+  const visible = new Set(visibleBagSeedIds.value)
+  return Object.entries(localStrategySettings.value.bagSeedLandTypes)
+    .map(([seedId, types]) => ({ seedId: Number(seedId), types: types || [] }))
+    .filter(item => item.seedId > 0 && item.types.length > 0 && !visible.has(item.seedId))
+    .sort((a, b) => a.seedId - b.seedId)
+    .map((item) => {
+      const known = seedOptions.value.find(seed => seed.seedId === item.seedId)
+      const labels = fertilizerLandTypeOptions
+        .filter(option => item.types.includes(option.value))
+        .map(option => option.label)
+      return {
+        seedId: item.seedId,
+        name: known ? known.name : `种子 #${item.seedId}`,
+        scope: `仅种 ${labels.join('、')}`,
+      }
+    })
 })
 
 function isAccountConnected(accountId: string) {
@@ -675,6 +710,7 @@ function syncLocalStrategySettings() {
       plantingStrategy: settings.value.plantingStrategy,
       preferredSeedId: settings.value.preferredSeedId,
       bagSeedPriority: settings.value.bagSeedPriority ?? [],
+      bagSeedLandTypes: settings.value.bagSeedLandTypes ?? {},
       bagSeedFallbackStrategy: settings.value.bagSeedFallbackStrategy ?? 'level',
       stealDelaySeconds: settings.value.stealDelaySeconds ?? 0,
       plantOrderRandom: !!settings.value.plantOrderRandom,
@@ -1611,6 +1647,9 @@ async function handleResetSystemConfig() {
                     <p class="mt-1 text-xs text-amber-700/90 dark:text-amber-300/90">
                       先按下方顺序消耗背包中的 1x1 / 2x2 种子；背包种子不足时，再按“第二优先策略”补种。切换第二优先策略或重置时会据此重新排序。
                     </p>
+                    <p class="mt-1 text-xs text-amber-700/90 dark:text-amber-300/90">
+                      配了土地限制的种子会先占用它能种的地块，再由不限制的种子使用剩余空地。
+                    </p>
                   </div>
                   <NButton
                     size="tiny"
@@ -1631,68 +1670,47 @@ async function handleResetSystemConfig() {
                   背包中暂无 1x1 / 2x2 种子
                 </div>
                 <div v-else class="grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
-                  <div
+                  <BagSeedPriorityItem
                     v-for="(seed, index) in sortedBagSeeds"
                     :key="seed.seedId"
-                    class="min-h-18 flex items-center gap-2 border cartoon-card border-amber-200 rounded-xl bg-white px-3 py-2.5 dark:border-amber-700/50 dark:bg-gray-800"
-                    :class="{ 'opacity-60 ring-2 ring-amber-400': draggingBagSeedId === seed.seedId }"
-                    draggable="true"
-                    @dragstart="startBagSeedDrag(seed.seedId, $event)"
-                    @dragend="endBagSeedDrag"
-                    @dragover.prevent="dragOverBagSeed(seed.seedId, $event)"
+                    :seed="seed"
+                    :index="index"
+                    :land-types="localStrategySettings.bagSeedLandTypes[String(seed.seedId)]"
+                    :land-type-options="fertilizerLandTypeOptions"
+                    :dragging="draggingBagSeedId === seed.seedId"
+                    :can-move-up="index > 0"
+                    :can-move-down="index < sortedBagSeeds.length - 1"
+                    @move-up="moveBagSeedUp(seed.seedId)"
+                    @move-down="moveBagSeedDown(seed.seedId)"
+                    @update:land-types="setBagSeedLandTypes(seed.seedId, $event)"
+                    @drag-start="startBagSeedDrag(seed.seedId, $event)"
+                    @drag-end="endBagSeedDrag"
+                    @drag-over="dragOverBagSeed(seed.seedId, $event)"
                     @drop="dropBagSeed(seed.seedId, $event)"
-                  >
-                    <div class="h-9 w-9 flex shrink-0 items-center justify-center rounded-lg bg-amber-100 text-xs text-amber-700 font-bold dark:bg-amber-900/50 dark:text-amber-300">
-                      {{ index + 1 }}
-                    </div>
-                    <div class="h-9 w-9 flex shrink-0 items-center justify-center overflow-hidden rounded-lg bg-amber-50 dark:bg-gray-700">
-                      <img
-                        v-if="seed.image && !bagSeedImageErrors[seed.seedId]"
-                        :src="seed.image"
-                        :alt="`${seed.name}种子`"
-                        class="h-9 w-9 object-contain"
-                        loading="lazy"
-                        @error="bagSeedImageErrors[seed.seedId] = true"
-                      >
-                      <span v-else class="i-carbon-sprout text-lg text-amber-500 dark:text-amber-300" />
-                    </div>
-                    <div class="min-w-0 flex-1">
-                      <div class="flex items-center gap-1.5">
-                        <div class="truncate text-sm text-gray-800 font-semibold dark:text-gray-200">
-                          {{ seed.name }}
-                        </div>
-                        <span class="shrink-0 rounded bg-amber-100 px-1.5 py-0.5 text-[10px] text-amber-700 font-semibold dark:bg-amber-900/50 dark:text-amber-300">
-                          {{ seed.plantSize }}x{{ seed.plantSize }}
-                        </span>
-                      </div>
-                      <div class="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
-                        库存 {{ seed.count }} · {{ seed.requiredLevel }} 级 · ID {{ seed.seedId }}
-                      </div>
-                    </div>
-                    <div class="flex shrink-0 flex-col gap-2">
-                      <NButton
-                        quaternary
-                        circle
-                        size="tiny"
-                        :disabled="index === 0"
-                        title="上移"
-                        aria-label="上移"
-                        @click="moveBagSeedUp(seed.seedId)"
-                      >
-                        <span :class="chevronUpIconClass" />
-                      </NButton>
-                      <NButton
-                        quaternary
-                        circle
-                        size="tiny"
-                        :disabled="index === sortedBagSeeds.length - 1"
-                        title="下移"
-                        aria-label="下移"
-                        @click="moveBagSeedDown(seed.seedId)"
-                      >
-                        <span :class="chevronDownIconClass" />
-                      </NButton>
-                    </div>
+                  />
+                </div>
+                <div v-if="orphanRestrictedSeeds.length > 0" class="border-t border-amber-200 pt-2 dark:border-amber-800/50">
+                  <div class="text-xs text-amber-800 dark:text-amber-300">
+                    未持有但已配限制
+                  </div>
+                  <p class="mt-1 text-[11px] text-amber-700/80 dark:text-amber-300/80">
+                    这些种子当前不在背包中，限制已保留，重新入库后仍生效。
+                  </p>
+                  <div class="mt-2 flex flex-wrap gap-1.5">
+                    <span
+                      v-for="item in orphanRestrictedSeeds"
+                      :key="item.seedId"
+                      class="inline-flex items-center gap-1 rounded-full bg-amber-100 px-2 py-1 text-[11px] text-amber-800 dark:bg-amber-900/40 dark:text-amber-200"
+                    >
+                      {{ item.name }} · {{ item.scope }}
+                      <button
+                        type="button"
+                        class="i-carbon-close text-amber-600 hover:text-amber-900 dark:text-amber-300 dark:hover:text-amber-100"
+                        :title="`清除 ${item.name} 的土地限制`"
+                        :aria-label="`清除 ${item.name} 的土地限制`"
+                        @click="setBagSeedLandTypes(item.seedId, [])"
+                      />
+                    </span>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## 概述

三个功能，均围绕土地与种植策略：

### 1. 施肥功能与界面支持
- 农场模块支持普通肥料与有机肥料施用，补齐相关 API 与错误反馈。
- 农场面板与土地卡片展示施肥状态，可直接发起施肥。

### 2. 显示地块手动施肥按钮（自动化设置）
- 新增开关控制手动施肥按钮是否出现在土地卡片上，默认沿用原有表现。

### 3. 背包种子优先顺序支持地块限制
- 背包优先种植原先只能顺序铺满空地，好地容易被普通种子占掉。现在每颗种子可单独限定可种土地类型（普通/红/黑/金/紫金），缺省不限制。
- 种植时**受限种子优先**挑走匹配地块，剩余空地再由不限制的种子按原优先级补满。
- 设置页三态交互：默认显示「土地：不限制」，展开后勾 1~4 种即生效；勾满或全不勾都收回为不限制，配置里不留该 key。
- 缺货种子的限制会保留，并在「未持有但已配限制」区块列出，可一键清除，避免出现看不见的规则。
- 顺带修正 `planting.ts` 中缺少「紫金土地」的土地类型常量，改为复用 `land-analysis` 的完整清单。

最后一个 commit 是 lint 自动修复（`Object.hasOwn`、`Array.from`、空值合并等等价写法），无行为变化。

## 验证

- `pnpm build:core`、`pnpm -C web typecheck`、`pnpm -C core test`（35 项）全部通过。
- 真机联机验证：设置页 27 颗背包种子默认全部「不限制」；对樱桃限「黑土地」、梨限「紫金+金土地」后保存，服务端存为 `{"20034":["black"],"20054":["purple-gold","gold"]}`，刷新后回显一致。
- 勾满 5 项自动收回「不限制」并从配置中删除该 key。
- 为未持有的种子写入限制后，设置页正确显示「草莓 · 仅种 红土地」，点清除并保存后配置同步移除。
- 验证完成后已将测试用的限制清空，未改动账号原有配置。

Made with [Cursor](https://cursor.com)