### PR TITLE
fix(friend): 帮助经验上限时置位全局标志，避免空转刷日志

### DIFF
--- a/core/src/services/friend/scheduler.ts
+++ b/core/src/services/friend/scheduler.ts
@@ -62,6 +62,8 @@ let badOperationLimitReached: boolean = false;
 // PutInsects additionally reports 10004, but 10003 is the shared daily quota.
 const BAD_SHARED_LIMIT_ID: number = 10003;
 const BAD_DAILY_STATE_VERSION: number = 1;
+// 帮助经验相关操作 ID（除草/除虫/浇水）
+const HELP_EXP_LIMIT_IDS: number[] = [10005, 10006, 10007];
 
 const OP_NAMES: Record<number, string> = {
     10001: '浇水',
@@ -174,6 +176,9 @@ export function updateOperationLimits(limits: any[]): void {
             operationLimits.set(id, data);
             if (id === BAD_SHARED_LIMIT_ID && data.dayTimesLimit > 0 && data.dayTimes >= data.dayTimesLimit) {
                 markBadOperationLimitReached('operation_limit');
+            }
+            if (HELP_EXP_LIMIT_IDS.includes(id) && data.dayExpTimesLimit > 0 && data.dayExpTimes >= data.dayExpTimesLimit) {
+                autoDisableHelpByExpLimit();
             }
         }
     }


### PR DESCRIPTION
### 问题

开启"经验满停止帮忙"且未开护主犬时，当帮助经验达到每日上限，好友巡查每轮仍然会打印"开始批量帮助"日志。

### 修复

打印日志前增加判断逻辑，经验已达上限且未开护主犬豁免时静默跳过整个帮助阶段，开护主犬时保持原有行为。