### PR TITLE
feat(settings): 添加 MeoW 推送渠道支持

### DIFF
--- a/core/src/models/store/shared-state.ts
+++ b/core/src/models/store/shared-state.ts
@@ -15,7 +15,7 @@ const PUSHOO_CHANNELS: Set<string> = new Set([
     'webhook', 'qmsg', 'serverchan', 'pushplus', 'pushplushxtrip',
     'dingtalk', 'wecom', 'bark', 'gocqhttp', 'onebot', 'atri',
     'pushdeer', 'igot', 'telegram', 'feishu', 'ifttt', 'wecombot',
-    'discord', 'wxpusher',
+    'discord', 'wxpusher', 'meow',
 ]);
 
 const DEFAULT_FERTILIZER_LAND_TYPES: FertilizerLandType[] = ['purple-gold', 'gold', 'black', 'red', 'normal'];

--- a/core/src/services/push.ts
+++ b/core/src/services/push.ts
@@ -8,6 +8,7 @@ const axios = require('axios').default;
 const pushoo = require('pushoo').default;
 
 const DINGTALK_WEBHOOK_PREFIX = 'https://oapi.dingtalk.com/robot/send?access_token=';
+const MEOW_DEFAULT_BASE_URL = 'https://api.chuckfang.com';
 
 function assertRequiredText(name: string, value: any): string {
     const text: string = String(value || '').trim();
@@ -75,6 +76,42 @@ async function sendDingTalkMessage(payload: any): Promise<any> {
 }
 
 /**
+ * 发送 MeoW 推送（鸿蒙 MeoW 消息推送 API）
+ * @param payload
+ * @param payload.token 必填 用户昵称（作为路径参数）
+ * @param payload.endpoint 可选 自定义接口地址（默认 https://api.chuckfang.com）
+ * @param payload.title 必填 推送标题
+ * @param payload.content 必填 推送内容
+ * @returns MeoW 推送结果
+ */
+async function sendMeowMessage(payload: any): Promise<any> {
+    const nickname = assertRequiredText('MeoW 昵称', payload.token);
+    const title = assertRequiredText('title', payload.title);
+    const content = assertRequiredText('content', payload.content);
+    const baseUrl = String(payload.endpoint || MEOW_DEFAULT_BASE_URL).trim().replace(/\/+$/, '');
+    if (!/^https?:\/\//i.test(baseUrl)) {
+        throw new Error('MeoW 接口地址格式无效');
+    }
+    const url = `${baseUrl}/${encodeURIComponent(nickname)}`;
+    const response = await axios.post(url, {
+        title,
+        msg: content,
+    });
+    const data: any = (response && response.data && typeof response.data === 'object') ? response.data : {};
+    const status: number = Number(data.status);
+    if (Number.isFinite(status) && status !== 200) {
+        // MeoW 业务状态码非 200 视为失败，转为 error 结构便于统一结果判断
+        return {
+            status,
+            error: {
+                message: String(data.msg || data.message || 'MeoW 推送失败'),
+            },
+        };
+    }
+    return data;
+}
+
+/**
  * 发送推送
  * @param payload
  * @param payload.channel 必填 推送渠道（pushoo 平台名，如 webhook）
@@ -108,7 +145,9 @@ async function sendPushooMessage(payload: any = {}): Promise<{ ok: boolean; code
 
     const result: any = channel === 'dingtalk'
         ? await sendDingTalkMessage({ endpoint, token, secret, title, content })
-        : await pushoo(channel, request);
+        : channel === 'meow'
+            ? await sendMeowMessage({ endpoint, token, title, content })
+            : await pushoo(channel, request);
 
     const raw: any = (result && typeof result === 'object') ? result : { data: result };
     const hasError: boolean = !!(raw && raw.error);
@@ -127,5 +166,6 @@ async function sendPushooMessage(payload: any = {}): Promise<{ ok: boolean; code
 module.exports = {
     buildDingTalkWebhook,
     createDingTalkSign,
+    sendMeowMessage,
     sendPushooMessage,
 };

--- a/web/src/views/Settings.vue
+++ b/web/src/views/Settings.vue
@@ -1061,6 +1061,7 @@ const channelOptions = [
   { label: '企业微信群机器人', value: 'wecombot' },
   { label: 'Discord', value: 'discord' },
   { label: 'WxPusher', value: 'wxpusher' },
+  { label: 'MeoW', value: 'meow' },
 ]
 
 const CHANNEL_DOCS: Record<string, string> = {
@@ -1083,15 +1084,21 @@ const CHANNEL_DOCS: Record<string, string> = {
   ifttt: 'https://ifttt.com/maker_webhooks',
   discord: 'https://discord.com/developers/docs/resources/webhook#execute-webhook',
   wxpusher: 'https://wxpusher.zjiecode.com/docs/#/',
+  meow: 'https://www.chuckfang.com/MeoW/api_doc.html',
 }
 
 const offlineChannel = computed(() => String(localOffline.value.channel || '').trim().toLowerCase())
 const isDingTalkChannel = computed(() => offlineChannel.value === 'dingtalk')
+const isMeowChannel = computed(() => offlineChannel.value === 'meow')
 const offlineChannelUsesEndpoint = computed(() => offlineChannel.value === 'webhook' || isDingTalkChannel.value)
 const offlineEndpointLabel = computed(() => isDingTalkChannel.value ? 'Webhook 地址' : '接口地址')
 const offlineEndpointPlaceholder = computed(() => isDingTalkChannel.value
   ? '从钉钉群机器人设置页复制完整 Webhook'
   : '接收消息的接口地址')
+const offlineTokenLabel = computed(() => isMeowChannel.value ? '昵称' : 'Token')
+const offlineTokenPlaceholder = computed(() => isMeowChannel.value
+  ? 'MeoW 注册昵称'
+  : '接收端 token')
 const currentChannelDocUrl = computed(() => CHANNEL_DOCS[offlineChannel.value] || '')
 
 function openChannelDocs() {
@@ -2066,9 +2073,9 @@ async function handleResetSystemConfig() {
                 <BaseInput
                   v-if="!isDingTalkChannel"
                   v-model="localOffline.token"
-                  label="Token"
+                  :label="offlineTokenLabel"
                   type="text"
-                  placeholder="接收端 token"
+                  :placeholder="offlineTokenPlaceholder"
                 />
 
                 <template v-else>


### PR DESCRIPTION
为项目新增 **MeoW** 推送渠道。MeoW 是面向鸿蒙（HarmonyOS）设备的轻量级消息推送服务：无需 SDK，通过一个 HTTP 请求即可向指定用户推送文本或 HTML 消息。官方 API 文档：https://www.chuckfang.com/MeoW/api_doc.html

集成后，用户可在「下线提醒」中选择 MeoW 渠道，将账号下线等系统消息实时推送到鸿蒙设备。

<img width="1260" height="2844" alt="fbffbc76fae01d0ce8dbdf17c5ce8ac1" src="https://github.com/user-attachments/assets/dbe2da6c-3a9a-4fd0-873d-39a7440278bc" />
<img width="1260" height="2844" alt="7f90edbc5624195744eab511e26dbfff" src="https://github.com/user-attachments/assets/98922471-3a58-463c-81b8-5d96b6afb4f1" />
