### PR TITLE
fix: 修复多季补肥不生效

### DIFF
--- a/core/src/config/gameConfig.ts
+++ b/core/src/config/gameConfig.ts
@@ -360,6 +360,31 @@ function getPlantGrowTime(plantId: number): number {
     return totalSeconds;
 }
 
+interface PlantGrowPhase {
+    index: number;
+    name: string;
+    duration: number;
+}
+
+/**
+ * 解析官方 Plant.grow_phases。官方客户端把每项转换成内部 phase_id；
+ * 服务端响应的 phases 是从当前阶段开始的配置后缀。
+ */
+function getPlantGrowPhases(plantId: number): PlantGrowPhase[] {
+    const plant = plantMap.get(Number(plantId) || 0);
+    if (!plant || !plant.grow_phases) return [];
+
+    return String(plant.grow_phases)
+        .split(';')
+        .filter(Boolean)
+        .map((value: string, index: number) => {
+            const separator = value.lastIndexOf(':');
+            const name = separator >= 0 ? value.slice(0, separator) : value;
+            const duration = separator >= 0 ? Number(value.slice(separator + 1)) || 0 : 0;
+            return { index, name, duration };
+        });
+}
+
 function formatGrowTime(seconds: number): string {
     if (seconds < 60) return `${seconds}秒`;
     if (seconds < 3600) return `${Math.floor(seconds / 60)}分钟`;
@@ -677,6 +702,7 @@ module.exports = {
     getPlantName,
     getPlantNameBySeedId,
     getPlantGrowTime,
+    getPlantGrowPhases,
     getPlantExp,
     formatGrowTime,
     // 果实配置

--- a/core/src/services/farm/land-analysis.ts
+++ b/core/src/services/farm/land-analysis.ts
@@ -10,11 +10,14 @@ const {
     getPlantById,
     getSeedImageBySeedId,
     getPlantGrowTime,
+    getPlantGrowPhases,
     getItemById,
     getMutantEffectsByIds,
     getMutantDisplayPlantId,
 } = require('../../config/gameConfig');
-const { toNum, toTimeSec, getServerTimeSec, logWarn } = require('../../utils/utils');
+const { toNum, toTimeSec, getServerTimeSec, log, logWarn } = require('../../utils/utils');
+
+const MATURE_PHASE_RECORD_ID = 19;
 
 function int64String(value: any): string {
     if (value == null) return '0';
@@ -312,7 +315,7 @@ function buildLandDetail(land: any, options: { friendMode?: boolean; landsMap?: 
         };
     }
 
-    const currentPhase = getCurrentPhase(plant.phases, false, '');
+    const currentPhase = getCurrentPhase(plant.phases, false, '', toNum(plant.id));
     if (!currentPhase) {
         return { ...base, status: 'empty', plantName: '', phaseName: '', currentSeason: 0, totalSeason: 0 };
     }
@@ -333,7 +336,11 @@ function buildLandDetail(land: any, options: { friendMode?: boolean; landsMap?: 
     const totalSeason = Math.max(1, toNum(plantCfg?.seasons) || 1);
     const currentSeasonRaw = toNum(plant.season);
     const currentSeason = currentSeasonRaw > 0 ? Math.min(currentSeasonRaw, totalSeason) : 1;
-    const maturePhase = plant.phases.find((phase: any) => toNum(phase?.phase) === PlantPhase.MATURE);
+    const maturePhase = Array.isArray(plant.phases)
+        ? plant.phases
+            .filter((phase: any) => phase && toTimeSec(phase.begin_time) > 0)
+            .sort((left: any, right: any) => toTimeSec(right.begin_time) - toTimeSec(left.begin_time))[0]
+        : null;
     const matureBegin = maturePhase ? toTimeSec(maturePhase.begin_time) : 0;
     const matureInSec = matureBegin > nowSec ? matureBegin - nowSec : 0;
     const statusFlags = getPlantStatusFlags(plant, currentPhase, nowSec);
@@ -355,7 +362,7 @@ function buildLandDetail(land: any, options: { friendMode?: boolean; landsMap?: 
         plantName,
         seedId,
         seedImage: seedId > 0 ? getSeedImageBySeedId(seedId) : '',
-        phaseName: PHASE_NAMES[phaseVal] || '',
+        phaseName: currentPhase.phaseName || PHASE_NAMES[phaseVal] || '',
         currentSeason,
         totalSeason,
         matureInSec,
@@ -377,37 +384,87 @@ function buildLandDetail(land: any, options: { friendMode?: boolean; landsMap?: 
     };
 }
 
-function getCurrentPhase(phases: any[], debug?: boolean, landLabel?: string): any | null {
+function getCurrentPhase(phases: any[], debug?: boolean, landLabel?: string, plantId: number = 0): any | null {
     if (!phases || phases.length === 0) return null;
 
     const nowSec: number = getServerTimeSec();
+    const resolvedPlantId = toNum(plantId);
 
     if (debug) {
         console.warn(`    ${landLabel} 服务器时间=${nowSec} (${new Date(nowSec * 1000).toLocaleTimeString()})`);
+        const growPhases = getPlantGrowPhases(resolvedPlantId);
         for (let i = 0; i < phases.length; i++) {
             const p = phases[i];
             const bt = toTimeSec(p.begin_time);
-            const phaseName = PHASE_NAMES[p.phase] || `阶段${p.phase}`;
+            const phaseName = growPhases[toNum(p.phase) - 1]?.name
+                || PHASE_NAMES[toNum(p.phase)]
+                || `阶段${p.phase}`;
             const diff = bt > 0 ? (bt - nowSec) : 0;
             const diffStr = diff > 0 ? `(未来 ${diff}s)` : diff < 0 ? `(已过 ${-diff}s)` : '';
             console.warn(`    ${landLabel}   [${i}] ${phaseName}(${p.phase}) begin=${bt} ${diffStr} dry=${toTimeSec(p.dry_time)} weed=${toTimeSec(p.weeds_time)} insect=${toTimeSec(p.insect_time)}`);
         }
     }
 
-    for (let i = phases.length - 1; i >= 0; i--) {
-        const beginTime = toTimeSec(phases[i].begin_time);
-        if (beginTime > 0 && beginTime <= nowSec) {
-            if (debug) {
-                console.warn(`    ${landLabel}   → 当前阶段: ${PHASE_NAMES[phases[i].phase] || phases[i].phase}`);
-            }
-            return phases[i];
-        }
-    }
-
+    const converted = convertServerPhaseToClient(phases, phases[0], resolvedPlantId);
     if (debug) {
-        console.warn(`    ${landLabel}   → 所有阶段都在未来，使用第一个: ${PHASE_NAMES[phases[0].phase] || phases[0].phase}`);
+        console.warn(`    ${landLabel}   → 当前阶段: ${converted?.phaseName || PHASE_NAMES[converted?.phase] || converted?.phase}`);
     }
-    return phases[0];
+    return converted;
+}
+
+/**
+ * phases 是从当前阶段开始的配置后缀，因此当前配置下标等于：
+ * grow_phases 总数 - 服务端剩余 phases 数。响应 phase 只表示生长中/成熟/枯死
+ * 等粗状态，phase_id 是详细阶段类型，二者都不能直接作为配置数组下标。
+ */
+function convertServerPhaseToClient(phases: any[], serverPhaseInfo: any, plantId: number): any | null {
+    if (!serverPhaseInfo) return null;
+    const serverPhase = toNum(serverPhaseInfo.phase);
+    const phaseRecordId = toNum(serverPhaseInfo.phase_id);
+    const growPhases = getPlantGrowPhases(plantId);
+    const remainingCount = Array.isArray(phases) ? phases.length : 0;
+    const phaseIndex = growPhases.length > 0 && remainingCount > 0
+        ? Math.max(0, growPhases.length - remainingCount)
+        : -1;
+    const configuredPhase = phaseIndex >= 0 ? growPhases[phaseIndex] : null;
+    const isFinalConfiguredPhase = growPhases.length > 0 && phaseIndex === growPhases.length - 1;
+    // 大多数作物成熟时 phase=6，但部分作物（例如最后阶段名为“盛开”的牵牛花）
+    // 仍可能返回粗状态 2，或把详细阶段 ID 19 放进 phase。成熟阶段同时可由
+    // phase_id=19 和 grow_phases 的最后一个剩余阶段确定，不能只依赖粗状态。
+    const isMature = serverPhase !== PlantPhase.DEAD && (
+        serverPhase === PlantPhase.MATURE
+        || serverPhase === MATURE_PHASE_RECORD_ID
+        || phaseRecordId === MATURE_PHASE_RECORD_ID
+        || (isFinalConfiguredPhase && (
+            serverPhase === PlantPhase.GERMINATION
+            || serverPhase > PlantPhase.DEAD
+        ))
+    );
+    const clientPhase = isMature ? PlantPhase.MATURE : serverPhase;
+    const imagePhase = serverPhase === PlantPhase.DEAD ? PlantPhase.DEAD : phaseIndex + 1;
+    const isKnownClientPhase = clientPhase >= PlantPhase.SEED && clientPhase <= PlantPhase.MATURE;
+    if (!configuredPhase && serverPhase !== PlantPhase.DEAD && !isKnownClientPhase) {
+        return {
+            ...serverPhaseInfo,
+            phase_index: phaseIndex,
+            image_phase: 0,
+            server_phase: serverPhase,
+            phase_record_id: phaseRecordId,
+            phase: PlantPhase.UNKNOWN,
+            phaseName: '未知阶段',
+        };
+    }
+    return {
+        ...serverPhaseInfo,
+        phase_index: phaseIndex,
+        image_phase: configuredPhase ? imagePhase : clientPhase,
+        server_phase: serverPhase,
+        phase_record_id: phaseRecordId,
+        phase: clientPhase,
+        phaseName: serverPhase === PlantPhase.DEAD
+            ? PHASE_NAMES[PlantPhase.DEAD]
+            : (configuredPhase && configuredPhase.name) || PHASE_NAMES[clientPhase],
+    };
 }
 
 function getOrganicFertilizerTargetsFromLands(lands: any[]): number[] {
@@ -420,7 +477,7 @@ function getOrganicFertilizerTargetsFromLands(lands: any[]): number[] {
 
         const plant = land.plant;
         if (!plant || !plant.phases || plant.phases.length === 0) continue;
-        const currentPhase = getCurrentPhase(plant.phases);
+        const currentPhase = getCurrentPhase(plant.phases, false, '', toNum(plant.id));
         if (!currentPhase) continue;
         if (currentPhase.phase === PlantPhase.DEAD) continue;
 
@@ -448,12 +505,14 @@ function getFastMatureLands(lands: any[], thresholdSec: number = 300): number[] 
 
         const plant = land.plant;
         if (!plant || !plant.phases || plant.phases.length === 0) continue;
-        const currentPhase = getCurrentPhase(plant.phases);
+        const currentPhase = getCurrentPhase(plant.phases, false, '', toNum(plant.id));
         if (!currentPhase) continue;
         if (currentPhase.phase === PlantPhase.DEAD) continue;
         if (currentPhase.phase === PlantPhase.MATURE) continue;
 
-        const maturePhase = plant.phases.find((p: any) => toNum(p.phase) === PlantPhase.MATURE);
+        const maturePhase = plant.phases
+            .filter((p: any) => p && toTimeSec(p.begin_time) > 0)
+            .sort((left: any, right: any) => toTimeSec(right.begin_time) - toTimeSec(left.begin_time))[0];
         if (!maturePhase) continue;
 
         const matureBeginTime = toTimeSec(maturePhase.begin_time);
@@ -690,7 +749,7 @@ function analyzeLands(lands: any[], debug?: boolean, ownGid?: number): {
         const plantName = plant.name || '未知作物';
         const landLabel = `土地#${id}(${plantName})`;
 
-        const currentPhase = getCurrentPhase(plant.phases, debug, landLabel);
+        const currentPhase = getCurrentPhase(plant.phases, debug, landLabel, toNum(plant.id));
         if (!currentPhase) {
             result.empty.push(id);
             continue;
@@ -875,7 +934,7 @@ function getLandLifecycleState(land: any): string {
         return 'empty';
     }
 
-    const currentPhase = getCurrentPhase(plant.phases, false, '');
+    const currentPhase = getCurrentPhase(plant.phases, false, '', toNum(plant.id));
     if (!currentPhase) return 'empty';
 
     const phaseVal = toNum(currentPhase.phase);
@@ -883,6 +942,16 @@ function getLandLifecycleState(land: any): string {
     if (phaseVal === PlantPhase.UNKNOWN) return 'empty';
     if (phaseVal >= PlantPhase.SEED && phaseVal <= PlantPhase.MATURE) return 'growing';
     return 'unknown';
+}
+
+function hasRemainingSeasons(plant: any): boolean {
+    if (!plant) return false;
+    const plantId = toNum(plant.id);
+    const plantCfg = plantId > 0 ? getPlantById(plantId) : null;
+    const totalSeason = Math.max(1, toNum(plantCfg && plantCfg.seasons) || 1);
+    const rawSeason = toNum(plant.season);
+    const currentSeason = rawSeason > 0 ? rawSeason : 1;
+    return currentSeason > 1 || currentSeason < totalSeason;
 }
 
 function classifyHarvestedLandsByMap(landIds: number[], landsMap: Map<number, any>): {
@@ -893,22 +962,47 @@ function classifyHarvestedLandsByMap(landIds: number[], landsMap: Map<number, an
     const removable: number[] = [];
     const growing: number[] = [];
     const unknown: number[] = [];
+    const details: Array<Record<string, unknown>> = [];
     for (const id of landIds) {
         const land = landsMap.get(id);
+        const plant = land && land.plant;
+        const phases = plant && Array.isArray(plant.phases) ? plant.phases : [];
+        const firstPhase = phases[0] || null;
+        let state = 'unknown';
         if (!land) {
             unknown.push(id);
-            continue;
+        } else {
+            state = getLandLifecycleState(land);
+            if (state === 'dead' || state === 'empty') {
+                removable.push(id);
+            } else if (state === 'growing' || hasRemainingSeasons(plant)) {
+                state = 'growing';
+                growing.push(id);
+            } else {
+                unknown.push(id);
+            }
         }
-        const state = getLandLifecycleState(land);
-        if (state === 'dead' || state === 'empty') {
-            removable.push(id);
-            continue;
-        }
-        if (state === 'growing') {
-            growing.push(id);
-            continue;
-        }
-        unknown.push(id);
+        details.push({
+            landId: id,
+            hasLand: !!land,
+            hasPlant: !!plant,
+            phases: phases.length,
+            phase: firstPhase ? toNum(firstPhase.phase) : 0,
+            phaseId: firstPhase ? toNum(firstPhase.phase_id) : 0,
+            season: plant ? toNum(plant.season) : 0,
+            state,
+        });
+    }
+    if (landIds.length > 0) {
+        log('农场', `收后分类 ${landIds.length} 块: 铲${removable.length}/长${growing.length}/未知${unknown.length}`, {
+            module: 'farm',
+            event: '收获后状态分类',
+            result: 'ok',
+            removable: [...removable],
+            growing: [...growing],
+            unknown: [...unknown],
+            details,
+        });
     }
     return { removable, growing, unknown };
 }
@@ -950,8 +1044,14 @@ async function resolveRemovableHarvestedLands(harvestedLandIds: number[], harves
     }
 
     if (unknown.length > 0) {
-        // 按兼容策略：不可判定时保持旧行为，继续铲除
-        removable.push(...unknown);
+        // 收获响应可能省略 2x2 主地块，或全量土地响应暂时不完整；
+        // 把未知状态当成枯死会误铲仍在生长/进入下一季的合种作物。
+        logWarn('农场', `收后仍有 ${unknown.length} 块土地状态未知，已跳过铲除 (${unknown.join(',')})`, {
+            module: 'farm',
+            event: '收获后状态补拉',
+            result: 'skip_unknown',
+            landIds: unknown,
+        });
         fallbackRemoved = unknown.length;
     }
 

--- a/core/src/services/farm/planting.ts
+++ b/core/src/services/farm/planting.ts
@@ -850,7 +850,25 @@ async function runFertilizerByConfig(plantedLands: any[] = [], options: { skipNo
 
     const { skipNormal = false } = options;
 
+    if (fertilizerConfig === 'none') {
+        log('施肥', `${reasonLabel}：当前施肥策略为不施肥，跳过`, {
+            module: 'farm',
+            event: eventName,
+            result: 'skip',
+            reason,
+            type: 'none',
+        });
+        return { normal: 0, organic: 0 };
+    }
+
     if (planted.length === 0 && fertilizerConfig !== 'organic' && fertilizerConfig !== 'both' && fertilizerConfig !== 'smart') {
+        log('施肥', `${reasonLabel}：没有可施肥地块，跳过`, {
+            module: 'farm',
+            event: eventName,
+            result: 'skip',
+            reason,
+            count: 0,
+        });
         return { normal: 0, organic: 0 };
     }
     let latestLands: any[] = [];
@@ -894,7 +912,18 @@ async function runFertilizerByConfig(plantedLands: any[] = [], options: { skipNo
     let fertilizedNormal: number = 0;
     let fertilizedOrganic: number = 0;
 
-    if (!skipNormal && (fertilizerConfig === 'normal' || fertilizerConfig === 'both' || fertilizerConfig === 'smart') && normalTargets.length > 0) {
+    if (!skipNormal && (fertilizerConfig === 'normal' || fertilizerConfig === 'both' || fertilizerConfig === 'smart')) {
+        if (normalTargets.length === 0) {
+            log('施肥', `${reasonLabel}：普通化肥目标为空（传入 ${planted.length} 块，范围: ${selectedLandTypeNames.join('、')}），跳过普通施肥`, {
+                module: 'farm',
+                event: eventName,
+                result: 'skip',
+                reason,
+                type: 'normal',
+                count: 0,
+                landTypes: selectedLandTypes,
+            });
+        } else {
         fertilizedNormal = await fertilize(normalTargets, NORMAL_FERTILIZER_ID, options.propagateErrors);
         if (fertilizedNormal > 0) {
             log('施肥', `${reasonLabel}：已为${fertilizedNormal}/${normalTargets.length} 块地施普通化肥（范围: ${selectedLandTypeNames.join('、')}）`, {
@@ -907,6 +936,17 @@ async function runFertilizerByConfig(plantedLands: any[] = [], options: { skipNo
             landTypes: selectedLandTypes,
         });
             recordOperation('fertilize', fertilizedNormal);
+            } else {
+                log('施肥', `${reasonLabel}：普通化肥施肥 0/${normalTargets.length} 块（可能化肥不足或地块不可施）`, {
+                    module: 'farm',
+                    event: eventName,
+                    result: 'skip',
+                    reason,
+                    type: 'normal',
+                    count: 0,
+                    landTypes: selectedLandTypes,
+                });
+            }
         }
     }
 
@@ -915,6 +955,10 @@ async function runFertilizerByConfig(plantedLands: any[] = [], options: { skipNo
 
         if (latestLands.length > 0) {
             organicTargets = getOrganicFertilizerTargetsFromLands(latestLands);
+        }
+        if (reason === 'multi_season' && planted.length > 0) {
+            const plantedSet = new Set(planted);
+            organicTargets = organicTargets.filter(id => plantedSet.has(id));
         }
         if (landTypeById.size > 0) {
             organicTargets = filterLandIdsByTypes(organicTargets, landTypeById, selectedLandTypes);

--- a/core/src/services/friend-interaction-items.ts
+++ b/core/src/services/friend-interaction-items.ts
@@ -292,7 +292,7 @@ function buildTargetLandMap(landsInput: any[], itemId: number, friendMode: boole
         if (landId <= 0 || targets.has(String(landId))) continue;
         const plant = sourceLand?.plant;
         if (!plant || !Array.isArray(plant.phases) || plant.phases.length === 0) continue;
-        const currentPhase = getCurrentPhase(plant.phases, false, '');
+        const currentPhase = getCurrentPhase(plant.phases, false, '', toNum(plant.id));
         const detail = buildLandDetail(sourceLand, { friendMode, landsMap });
         if (!isEligibleInteractionTarget(itemId, detail, currentPhase)) continue;
         targets.set(String(landId), {

--- a/core/src/services/friend/visit-strategy.ts
+++ b/core/src/services/friend/visit-strategy.ts
@@ -103,7 +103,7 @@ function pruneRecentHelp(now: number = Date.now()): void {
 function getHelpSnapshotKey(lands: any[]): string {
     return (Array.isArray(lands) ? lands : []).map((land: any) => {
         const plant: any = land && land.plant;
-        const phase: any = plant && Array.isArray(plant.phases) ? getCurrentPhase(plant.phases) : null;
+        const phase: any = plant && Array.isArray(plant.phases) ? getCurrentPhase(plant.phases, false, '', toNum(plant && plant.id)) : null;
         const weeds: string = (plant && Array.isArray(plant.weed_owners) ? plant.weed_owners : []).map(toNum).join(',');
         const insects: string = (plant && Array.isArray(plant.insect_owners) ? plant.insect_owners : []).map(toNum).join(',');
         return [
@@ -311,7 +311,7 @@ export function analyzeFriendLands(lands: any[], myGid: number, friendName: stri
             continue;
         }
 
-        const currentPhase: any = getCurrentPhase(plant.phases, false, `[${friendName}]土地#${id}`);
+        const currentPhase: any = getCurrentPhase(plant.phases, false, `[${friendName}]土地#${id}`, toNum(plant.id));
         if (!currentPhase) {
             continue;
         }

--- a/core/src/services/weather-activity.ts
+++ b/core/src/services/weather-activity.ts
@@ -322,7 +322,7 @@ function cloudEligibleLandIds(lands: any[]): string[] {
         if (landId === '0' || seen.has(landId)) continue;
         const plant = targetLand?.plant;
         if (!plant || toNum(plant.id) <= 0 || !Array.isArray(plant.phases) || plant.phases.length === 0) continue;
-        const phase = toNum(getCurrentPhase(plant.phases, false, '')?.phase);
+        const phase = toNum(getCurrentPhase(plant.phases, false, '', toNum(plant.id))?.phase);
         if (phase <= PlantPhase.SEED || phase >= PlantPhase.MATURE) continue;
         const interactions = [
             ...(Array.isArray(plant.interaction_uses) ? plant.interaction_uses : []),

--- a/core/tests/farm-multi-season.test.js
+++ b/core/tests/farm-multi-season.test.js
@@ -1,0 +1,180 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { PlantPhase } = require('../dist/config/config');
+const { getPlantById, getPlantGrowPhases } = require('../dist/config/gameConfig');
+const {
+    analyzeLands,
+    classifyHarvestedLandsByMap,
+    getCurrentPhase,
+    resolveRemovableHarvestedLands,
+} = require('../dist/services/farm/land-analysis');
+
+const MUSHROOM_ID = 1020050;
+const RADISH_ID = 2020002;
+const MORNING_GLORY_ID = 1020147;
+
+function land(id, plant) {
+    return { id, unlocked: true, plant };
+}
+
+test('getPlantGrowPhases parses multi-season and 盛开-final crops', () => {
+    const mushroom = getPlantGrowPhases(MUSHROOM_ID);
+    assert.ok(mushroom.length >= 2);
+    assert.equal(mushroom[mushroom.length - 1].name, '成熟');
+    assert.equal(getPlantById(MUSHROOM_ID).seasons, 2);
+
+    const glory = getPlantGrowPhases(MORNING_GLORY_ID);
+    assert.equal(glory[glory.length - 1].name, '盛开');
+});
+
+test('getCurrentPhase uses phases[0] even when a later phase is already in the past', () => {
+    const now = Math.floor(Date.now() / 1000);
+    const current = getCurrentPhase([
+        { phase: PlantPhase.GERMINATION, begin_time: now - 100 },
+        { phase: PlantPhase.MATURE, begin_time: now - 10 },
+    ], false, '', RADISH_ID);
+    assert.equal(current.phase, PlantPhase.GERMINATION);
+});
+
+test('getCurrentPhase maps phase_id 19 to MATURE', () => {
+    const now = Math.floor(Date.now() / 1000);
+    const current = getCurrentPhase([
+        { phase: PlantPhase.GERMINATION, phase_id: 19, begin_time: now - 10 },
+        { phase: PlantPhase.MATURE, begin_time: now + 100 },
+        { phase: PlantPhase.MATURE, begin_time: now + 200 },
+    ], false, '', MUSHROOM_ID);
+    assert.equal(current.phase, PlantPhase.MATURE);
+});
+
+test('getCurrentPhase maps a final configured 盛开 remaining phase to MATURE', () => {
+    const now = Math.floor(Date.now() / 1000);
+    const current = getCurrentPhase([
+        { phase: PlantPhase.GERMINATION, begin_time: now - 10 },
+    ], false, '', MORNING_GLORY_ID);
+    assert.equal(current.phase, PlantPhase.MATURE);
+});
+
+test('classifyHarvestedLandsByMap: dead and empty go to removable, missing land stays unknown', () => {
+    const now = Math.floor(Date.now() / 1000);
+    const map = new Map([
+        [1, land(1, { id: RADISH_ID, season: 1, phases: [{ phase: PlantPhase.DEAD, begin_time: now }] })],
+        [2, land(2, null)],
+        [3, land(3, { id: RADISH_ID, season: 1, phases: [] })],
+    ]);
+    const result = classifyHarvestedLandsByMap([1, 2, 3, 99], map);
+    assert.deepEqual(result.removable.slice().sort((a, b) => a - b), [1, 2, 3]);
+    assert.deepEqual(result.growing, []);
+    assert.deepEqual(result.unknown, [99]);
+});
+
+test('classifyHarvestedLandsByMap: next-season multi-crop is growing, not removable', () => {
+    const now = Math.floor(Date.now() / 1000);
+    const map = new Map([
+        [4, land(4, {
+            id: MUSHROOM_ID,
+            season: 2,
+            phases: [
+                { phase: PlantPhase.GERMINATION, begin_time: now - 10 },
+                { phase: PlantPhase.MATURE, begin_time: now + 3600 },
+            ],
+        })],
+    ]);
+    const result = classifyHarvestedLandsByMap([4], map);
+    assert.deepEqual(result.growing, [4]);
+    assert.deepEqual(result.removable, []);
+    assert.deepEqual(result.unknown, []);
+});
+
+test('classifyHarvestedLandsByMap: unusual phase still growing when seasons remain', () => {
+    const now = Math.floor(Date.now() / 1000);
+    const map = new Map([
+        [5, land(5, {
+            id: MUSHROOM_ID,
+            season: 1,
+            phases: [
+                { phase: 20, phase_id: 20, begin_time: now - 10 },
+                { phase: PlantPhase.MATURE, begin_time: now + 3600 },
+            ],
+        })],
+    ]);
+    const result = classifyHarvestedLandsByMap([5], map);
+    assert.deepEqual(result.growing, [5]);
+    assert.deepEqual(result.removable, []);
+});
+
+test('classifyHarvestedLandsByMap: unusual phase on a single-season crop stays unknown', () => {
+    const now = Math.floor(Date.now() / 1000);
+    const map = new Map([
+        [6, land(6, {
+            id: RADISH_ID,
+            season: 1,
+            phases: [
+                { phase: 20, phase_id: 20, begin_time: now - 10 },
+                { phase: PlantPhase.MATURE, begin_time: now + 60 },
+            ],
+        })],
+    ]);
+    const result = classifyHarvestedLandsByMap([6], map);
+    assert.deepEqual(result.unknown, [6]);
+    assert.deepEqual(result.removable, []);
+    assert.deepEqual(result.growing, []);
+});
+
+test('classifyHarvestedLandsByMap: dead last season of a multi-crop is removable', () => {
+    const now = Math.floor(Date.now() / 1000);
+    const map = new Map([
+        [7, land(7, {
+            id: MUSHROOM_ID,
+            season: 2,
+            phases: [{ phase: PlantPhase.DEAD, begin_time: now }],
+        })],
+    ]);
+    const result = classifyHarvestedLandsByMap([7], map);
+    assert.deepEqual(result.removable, [7]);
+    assert.deepEqual(result.growing, []);
+});
+
+test('resolveRemovableHarvestedLands skips unknown instead of treating it as removable', async () => {
+    const result = await resolveRemovableHarvestedLands([99], { land: [] });
+    assert.deepEqual(result.removable, []);
+    assert.deepEqual(result.growing, []);
+    assert.equal(result.fallbackRemoved, 1);
+});
+
+test('resolveRemovableHarvestedLands classifies a mixed harvest reply without shovel next-season crops', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const result = await resolveRemovableHarvestedLands([1, 2], {
+        land: [
+            land(1, { id: RADISH_ID, season: 1, phases: [{ phase: PlantPhase.DEAD, begin_time: now }] }),
+            land(2, {
+                id: MUSHROOM_ID,
+                season: 2,
+                phases: [
+                    { phase: PlantPhase.GERMINATION, begin_time: now - 10 },
+                    { phase: PlantPhase.MATURE, begin_time: now + 3600 },
+                ],
+            }),
+        ],
+    });
+    assert.deepEqual(result.removable, [1]);
+    assert.deepEqual(result.growing, [2]);
+    assert.equal(result.fallbackRemoved, 0);
+});
+
+test('analyzeLands still harvests a radish at phase 6', () => {
+    const now = Math.floor(Date.now() / 1000);
+    const status = analyzeLands([
+        land(1, { id: RADISH_ID, season: 1, phases: [{ phase: PlantPhase.MATURE, begin_time: now - 10 }] }),
+    ]);
+    assert.deepEqual(status.harvestable, [1]);
+    assert.deepEqual(status.dead, []);
+});
+
+test('analyzeLands treats morning glory final remaining phase as harvestable', () => {
+    const now = Math.floor(Date.now() / 1000);
+    const status = analyzeLands([
+        land(8, { id: MORNING_GLORY_ID, season: 1, phases: [{ phase: PlantPhase.GERMINATION, begin_time: now - 10 }] }),
+    ]);
+    assert.deepEqual(status.harvestable, [8]);
+});


### PR DESCRIPTION
## Summary
- 收获后无法判定的地块不再按兼容策略当成枯地铲除，避免把进入下一季的多季作物铲掉，导致 `growing` 恒为空、多季补肥开关无效。
- 阶段判定改为取 `phases[0]`，并用 `grow_phases` 剩余条数、`phase_id=19` 和末阶段兜底识别成熟；同时用 `plant.season` / 作物 `seasons` 显式把下一季地块归入续种。
- 补齐施肥静默路径日志；`organic` / `both` 的多季补肥与传入地块求交集，避免退化成全场施肥。

## Test plan
- [ ] 打开多季补肥，施肥策略选智能/普通化肥，收获一批多季作物
- [ ] 日志出现「检测到多季作物进入后续季，准备执行多季补肥」以及后续施肥结果（成功或「施肥 0 次」原因）
- [ ] 多季作物收获后不会被立刻铲除重种，第二季能继续生长
- [ ] 单季作物收获后仍会正常铲除并重种
- [ ] `cd core && pnpm test`（已包含 `farm-multi-season.test.js`）


Made with [Cursor](https://cursor.com)