### PR TITLE
fix: 分析页参考等级最高 Lv200 并排除 id 为 29999 的白萝卜种子

### DIFF
--- a/core/src/services/analytics.ts
+++ b/core/src/services/analytics.ts
@@ -5,6 +5,8 @@ export {};
 
 const { getAllPlants, getFruitPrice, getSeedPrice, getItemImageById, getItemById } = require('../config/gameConfig');
 
+const EXCLUDED_RADISH_SEED_ID = 29999;
+
 function parseGrowTime(growPhases: string): number {
     if (!growPhases) return 0;
     const phases: string[] = growPhases.split(';').filter((p: string) => p.length > 0);
@@ -62,10 +64,11 @@ interface PlantRankingResult {
 function getPlantRankings(sortBy: string = 'exp'): PlantRankingResult[] {
     const plants: any[] = getAllPlants();
 
-    // 筛选普通作物
+    // 筛选普通作物，排除 id 为 29999 的白萝卜种子。
     const normalPlants: any[] = plants.filter((p: any) => {
-        // 放宽条件，只要有种子ID且有生长阶段数据
-        return p.seed_id > 0 && p.grow_phases;
+        return Number(p.seed_id) !== EXCLUDED_RADISH_SEED_ID
+            && p.seed_id > 0
+            && p.grow_phases;
     });
 
     const results: PlantRankingResult[] = [];

--- a/web/src/views/Analytics.vue
+++ b/web/src/views/Analytics.vue
@@ -375,7 +375,7 @@ function getSeedNameById(seedId: number) {
                   v-model:value="strategyLevel"
                   class="w-24"
                   :min="1"
-                  :max="100"
+                  :max="200"
                   :show-button="false"
                   size="small"
                 />


### PR DESCRIPTION
1. 修复了分析页参考等级最高 100 级的限制
2. 在分析时排除 2 秒成熟的白萝卜种子（id 29999）