### PR TITLE
fix: 为高优先级多格种子预留土地

### DIFF
--- a/core/src/controllers/admin/account-routes.ts
+++ b/core/src/controllers/admin/account-routes.ts
@@ -370,6 +370,7 @@ function mountAccountRoutes(app: Application, ctx: AdminContext): void {
             const fertilizerBuyNormalThresholdHours = id && (typeof store.getFertilizerBuyNormalThresholdHours === 'function') ? store.getFertilizerBuyNormalThresholdHours(id) : 10;
             const fertilizerBuyCheckIntervalMinutes = id && (typeof store.getFertilizerBuyCheckIntervalMinutes === 'function') ? store.getFertilizerBuyCheckIntervalMinutes(id) : 30;
             const bagSeedPriority = id && (typeof store.getBagSeedPriority === 'function') ? store.getBagSeedPriority(id) : [];
+            const bagSeedMultiLandReservationEnabled = id && (typeof store.getBagSeedMultiLandReservationEnabled === 'function') ? store.getBagSeedMultiLandReservationEnabled(id) : false;
             const bagSeedLandTypes = id && (typeof store.getBagSeedLandTypes === 'function') ? store.getBagSeedLandTypes(id) : {};
             const bagSeedFallbackStrategy = id && (typeof store.getBagSeedFallbackStrategy === 'function') ? store.getBagSeedFallbackStrategy(id) : 'level';
             const autoAcceptFriendMinLevel = id && (typeof store.getAutoAcceptFriendMinLevel === 'function') ? store.getAutoAcceptFriendMinLevel(id) : 0;
@@ -381,7 +382,7 @@ function mountAccountRoutes(app: Application, ctx: AdminContext): void {
             const offlineReminder = store.getOfflineReminder
                 ? store.getOfflineReminder()
                 : { channel: 'webhook', endpoint: '', token: '', secret: '', title: '账号下线提醒', msg: '账号下线', offlineDeleteSec: 0 };
-            res.json({ ok: true, data: { intervals, strategy, preferredSeed, friendQuietHours, automation, stealDelaySeconds, plantOrderRandom, plantDelaySeconds, fertilizerBuyOrganicCount, fertilizerBuyOrganicThresholdHours, fertilizerBuyNormalCount, fertilizerBuyNormalThresholdHours, fertilizerBuyCheckIntervalMinutes, bagSeedPriority, bagSeedLandTypes, bagSeedFallbackStrategy, autoAcceptFriendMinLevel, autoAcceptRequireOwnLevel, autoAcceptHarvestStealEnabled, autoAcceptHarvestStealHarvest, autoAcceptHarvestStealSteal, ui, offlineReminder } });
+            res.json({ ok: true, data: { intervals, strategy, preferredSeed, friendQuietHours, automation, stealDelaySeconds, plantOrderRandom, plantDelaySeconds, fertilizerBuyOrganicCount, fertilizerBuyOrganicThresholdHours, fertilizerBuyNormalCount, fertilizerBuyNormalThresholdHours, fertilizerBuyCheckIntervalMinutes, bagSeedPriority, bagSeedMultiLandReservationEnabled, bagSeedLandTypes, bagSeedFallbackStrategy, autoAcceptFriendMinLevel, autoAcceptRequireOwnLevel, autoAcceptHarvestStealEnabled, autoAcceptHarvestStealHarvest, autoAcceptHarvestStealSteal, ui, offlineReminder } });
         } catch (e: any) {
             handleApiError(res, e);
         }

--- a/core/src/models/store/account-config.ts
+++ b/core/src/models/store/account-config.ts
@@ -98,6 +98,7 @@ function getConfigSnapshot(accountId?: unknown): AccountConfig & { ui: typeof gl
         fertilizerBuyNormalThresholdHours: Math.max(0, Math.min(990, Number(cfg.fertilizerBuyNormalThresholdHours) || 0)),
         fertilizerBuyCheckIntervalMinutes: Math.max(1, Math.min(1440, Number(cfg.fertilizerBuyCheckIntervalMinutes) || 30)),
         bagSeedPriority: [...(cfg.bagSeedPriority || [])],
+        bagSeedMultiLandReservationEnabled: !!cfg.bagSeedMultiLandReservationEnabled,
         bagSeedLandTypes: cloneBagSeedLandTypes(cfg.bagSeedLandTypes),
         bagSeedFallbackStrategy: cfg.bagSeedFallbackStrategy,
         autoAcceptFriendMinLevel: cfg.autoAcceptFriendMinLevel,
@@ -231,6 +232,10 @@ function applyConfigSnapshot(snapshot: Record<string, any> | undefined, options:
         next.bagSeedPriority = normalizeBagSeedPriority(cfg.bagSeedPriority);
     }
 
+    if (cfg.bagSeedMultiLandReservationEnabled !== undefined && cfg.bagSeedMultiLandReservationEnabled !== null) {
+        next.bagSeedMultiLandReservationEnabled = !!cfg.bagSeedMultiLandReservationEnabled;
+    }
+
     if (cfg.bagSeedLandTypes !== undefined && cfg.bagSeedLandTypes !== null) {
         next.bagSeedLandTypes = normalizeBagSeedLandTypes(cfg.bagSeedLandTypes);
     }
@@ -295,6 +300,10 @@ function getPlantingStrategy(accountId?: unknown): PlantingStrategy {
 
 function getBagSeedPriority(accountId?: unknown): number[] {
     return [...(getAccountConfigSnapshot(accountId).bagSeedPriority || [])];
+}
+
+function getBagSeedMultiLandReservationEnabled(accountId?: unknown): boolean {
+    return !!getAccountConfigSnapshot(accountId).bagSeedMultiLandReservationEnabled;
 }
 
 function getBagSeedLandTypes(accountId?: unknown): Record<string, FertilizerLandType[]> {
@@ -474,6 +483,7 @@ module.exports = {
     getPreferredSeed,
     getPlantingStrategy,
     getBagSeedPriority,
+    getBagSeedMultiLandReservationEnabled,
     getBagSeedLandTypes,
     getBagSeedFallbackStrategy,
     getIntervals,

--- a/core/src/models/store/index.ts
+++ b/core/src/models/store/index.ts
@@ -14,6 +14,7 @@ module.exports = {
     getPreferredSeed: accountConfig.getPreferredSeed,
     getPlantingStrategy: accountConfig.getPlantingStrategy,
     getBagSeedPriority: accountConfig.getBagSeedPriority,
+    getBagSeedMultiLandReservationEnabled: accountConfig.getBagSeedMultiLandReservationEnabled,
     getBagSeedLandTypes: accountConfig.getBagSeedLandTypes,
     getBagSeedFallbackStrategy: accountConfig.getBagSeedFallbackStrategy,
     getIntervals: accountConfig.getIntervals,

--- a/core/src/models/store/shared-state.ts
+++ b/core/src/models/store/shared-state.ts
@@ -115,6 +115,7 @@ const DEFAULT_ACCOUNT_CONFIG: AccountConfig = {
     fertilizerBuyNormalThresholdHours: 10,
     fertilizerBuyCheckIntervalMinutes: 60,
     bagSeedPriority: [],
+    bagSeedMultiLandReservationEnabled: false,
     bagSeedLandTypes: {},
     bagSeedFallbackStrategy: 'level',
     autoAcceptFriendMinLevel: 0,
@@ -313,6 +314,9 @@ function cloneAccountConfig(base: Partial<AccountConfig> = DEFAULT_ACCOUNT_CONFI
         fertilizerBuyNormalThresholdHours: Math.max(0, Math.min(990, Number(base.fertilizerBuyNormalThresholdHours) || 0)),
         fertilizerBuyCheckIntervalMinutes: Math.max(1, Math.min(1440, Number(base.fertilizerBuyCheckIntervalMinutes) || 30)),
         bagSeedPriority: normalizeBagSeedPriority(base.bagSeedPriority),
+        bagSeedMultiLandReservationEnabled: base.bagSeedMultiLandReservationEnabled !== undefined
+            ? !!base.bagSeedMultiLandReservationEnabled
+            : DEFAULT_ACCOUNT_CONFIG.bagSeedMultiLandReservationEnabled,
         bagSeedLandTypes: normalizeBagSeedLandTypes(base.bagSeedLandTypes),
         bagSeedFallbackStrategy: normalizeBagSeedFallbackStrategy(base.bagSeedFallbackStrategy),
         autoAcceptFriendMinLevel: normalizeAutoAcceptFriendMinLevel(base.autoAcceptFriendMinLevel, DEFAULT_ACCOUNT_CONFIG.autoAcceptFriendMinLevel),
@@ -435,6 +439,10 @@ function normalizeAccountConfig(input: unknown, fallback: AccountConfig = accoun
 
     if (src.bagSeedPriority !== undefined && src.bagSeedPriority !== null) {
         cfg.bagSeedPriority = normalizeBagSeedPriority(src.bagSeedPriority);
+    }
+
+    if (src.bagSeedMultiLandReservationEnabled !== undefined && src.bagSeedMultiLandReservationEnabled !== null) {
+        cfg.bagSeedMultiLandReservationEnabled = !!src.bagSeedMultiLandReservationEnabled;
     }
 
     if (src.bagSeedLandTypes !== undefined && src.bagSeedLandTypes !== null) {

--- a/core/src/runtime/data-provider.ts
+++ b/core/src/runtime/data-provider.ts
@@ -289,6 +289,7 @@ function createDataProvider(options: DataProviderOptions) {
                 'fertilizerBuyNormalThresholdHours',
                 'fertilizerBuyCheckIntervalMinutes',
                 'bagSeedPriority',
+                'bagSeedMultiLandReservationEnabled',
                 'bagSeedLandTypes',
                 'bagSeedFallbackStrategy',
                 'autoAcceptFriendMinLevel',

--- a/core/src/services/farm/layout-reservation.ts
+++ b/core/src/services/farm/layout-reservation.ts
@@ -1,0 +1,52 @@
+export {};
+
+const { toNum } = require('../../utils/utils');
+const { buildPlantingLayouts } = require('./land-analysis');
+
+interface PlantingLayout {
+    anchorLandId: number;
+    landIds: number[];
+}
+
+interface FutureLayoutReservation {
+    layout: PlantingLayout;
+    reservedLandIds: number[];
+}
+
+/**
+ * 为暂时凑不齐的多格作物选择一组未来布局，并只预留其中当前已经空出的土地。
+ * 始终选择锚点最小且已经部分空出的布局，使后续轮次只会向更早布局收敛，避免来回切换。
+ */
+function selectFutureLayoutReservation(
+    currentEmptyLandIds: any[],
+    allEligibleLandIds: any[],
+    plantSize: number,
+): FutureLayoutReservation | null {
+    const size = Math.max(1, toNum(plantSize) || 1);
+    if (size <= 1) return null;
+
+    const emptyIds = new Set<number>((Array.isArray(currentEmptyLandIds) ? currentEmptyLandIds : [])
+        .map((id: any) => toNum(id))
+        .filter((id: number) => id > 0));
+    if (emptyIds.size === 0) return null;
+    if (buildPlantingLayouts([...emptyIds], size).length > 0) return null;
+
+    const candidates = buildPlantingLayouts(allEligibleLandIds, size)
+        .map((layout: PlantingLayout) => ({
+            layout,
+            reservedLandIds: layout.landIds.filter((id: number) => emptyIds.has(id)),
+        }))
+        .filter((candidate: FutureLayoutReservation) => (
+            candidate.reservedLandIds.length > 0
+            && candidate.reservedLandIds.length < candidate.layout.landIds.length
+        ))
+        .sort((a: FutureLayoutReservation, b: FutureLayoutReservation) => (
+            a.layout.anchorLandId - b.layout.anchorLandId
+        ));
+
+    return candidates[0] || null;
+}
+
+module.exports = {
+    selectFutureLayoutReservation,
+};

--- a/core/src/services/farm/planting.ts
+++ b/core/src/services/farm/planting.ts
@@ -14,6 +14,7 @@ const { recordOperation } = require('../stats');
 const { getBagSeeds } = require('../warehouse');
 const { getCareerInfoOrNull } = require('../career');
 const { getAllLands, buyGoods, removePlant, fertilizeOne } = require('./api');
+const { selectFutureLayoutReservation } = require('./layout-reservation');
 const {
     ALL_FERTILIZER_LAND_TYPES,
     buildLandDetail,
@@ -226,22 +227,32 @@ function resolveSeedLandTypes(bagSeedLandTypes: any, seedId: any): string[] | nu
     return types;
 }
 
-async function plantFromBagSeeds(landsToPlant: any[], landTypeById?: Map<number, string>, options: { propagateErrors?: boolean } = {}): Promise<{
+async function plantFromBagSeeds(landsToPlant: any[], landTypeById?: Map<number, string>, options: {
+    propagateErrors?: boolean;
+    allUnlockedLandIds?: number[];
+} = {}): Promise<{
     remainingLandIds: number[];
     fallbackAllowed: boolean;
     plantedLandIds: number[];
     totalPlanted: number;
     occupiedCount: number;
+    deferredLandIds: number[];
 }> {
     const targetLandIds: number[] = [...new Set((Array.isArray(landsToPlant) ? landsToPlant : [])
         .map((id: any) => toNum(id)).filter(Boolean))];
     if (targetLandIds.length === 0) {
-        return { remainingLandIds: [], fallbackAllowed: false, plantedLandIds: [], totalPlanted: 0, occupiedCount: 0 };
+        return { remainingLandIds: [], fallbackAllowed: false, plantedLandIds: [], totalPlanted: 0, occupiedCount: 0, deferredLandIds: [] };
     }
 
     const bagSeeds = await getBagSeeds();
     const state = getUserState();
     const priorityList = getBagSeedPriority();
+    const explicitPrioritySeedIds = new Set<number>((Array.isArray(priorityList) ? priorityList : [])
+        .map((seedId: any) => toNum(seedId))
+        .filter((seedId: number) => seedId > 0));
+    const allUnlockedLandIds = [...new Set<number>((Array.isArray(options.allUnlockedLandIds) ? options.allUnlockedLandIds : [])
+        .map((id: any) => toNum(id))
+        .filter((id: number) => id > 0))];
     const bagSeedLandTypes = getBagSeedLandTypes() || {};
     const landTypeAvailable = !!(landTypeById && landTypeById.size > 0);
     const allBagSeeds = (Array.isArray(bagSeeds) ? bagSeeds : []);
@@ -315,7 +326,7 @@ async function plantFromBagSeeds(landsToPlant: any[], landTypeById?: Map<number,
         log('种植', '背包种子已用完，准备按第二优先策略补种', {
             module: 'farm', event: '种植种子', result: 'fallback_ready', strategy: 'bag_priority'
         });
-        return { remainingLandIds: targetLandIds, fallbackAllowed: true, plantedLandIds: [], totalPlanted: 0, occupiedCount: 0 };
+        return { remainingLandIds: targetLandIds, fallbackAllowed: true, plantedLandIds: [], totalPlanted: 0, occupiedCount: 0, deferredLandIds: [] };
     }
 
     let remainingLandIds: number[] = [...targetLandIds];
@@ -324,6 +335,8 @@ async function plantFromBagSeeds(landsToPlant: any[], landTypeById?: Map<number,
     const occupiedIds = new Set<number>();
     const plantedLandIds: number[] = [];
     const usedSeedLogs: string[] = [];
+    const deferredLandIds = new Set<number>();
+    let futureLayoutReserved = false;
 
     for (const seed of plantingOrder) {
         if (remainingLandIds.length === 0 || !fallbackAllowed) break;
@@ -346,11 +359,33 @@ async function plantFromBagSeeds(landsToPlant: any[], landTypeById?: Map<number,
             const reason = seed.landTypes && allowedLandIds.length === 0
                 ? `无${formatFertilizerLandTypes(seed.landTypes).join('/')}空地`
                 : `无合法${plantSize}x${plantSize} 布局`;
-            log('种植', `背包种子 ${seed.name} ${reason}，已跳过`, {
-                module: 'farm', event: '种植种子', result: 'skip_no_layout', strategy: 'bag_priority',
-                seedId: seed.seedId, plantSize, emptyCount: remainingLandIds.length,
-                landTypes: seed.landTypes || null, allowedCount: allowedLandIds.length,
-            });
+            const allEligibleLandIds = seed.landTypes
+                ? filterLandIdsByTypes(allUnlockedLandIds, landTypeById, seed.landTypes)
+                : allUnlockedLandIds;
+            const reservation = !futureLayoutReserved
+                && plantSize > 1
+                && explicitPrioritySeedIds.has(toNum(seed.seedId))
+                ? selectFutureLayoutReservation(allowedLandIds, allEligibleLandIds, plantSize)
+                : null;
+            if (reservation) {
+                reservation.reservedLandIds.forEach((id: number) => deferredLandIds.add(id));
+                const reserved = new Set(reservation.reservedLandIds);
+                remainingLandIds = remainingLandIds.filter(id => !reserved.has(id));
+                futureLayoutReserved = true;
+                log('种植', `背包种子 ${seed.name} ${reason}，已预留空地 ${reservation.reservedLandIds.join(',')}，等待布局 ${reservation.layout.landIds.join(',')}`, {
+                    module: 'farm', event: '种植种子', result: 'reserve_future_layout', strategy: 'bag_priority',
+                    seedId: seed.seedId, plantSize, emptyCount: remainingLandIds.length + reservation.reservedLandIds.length,
+                    landTypes: seed.landTypes || null, allowedCount: allowedLandIds.length,
+                    reservedLandIds: reservation.reservedLandIds,
+                    targetLandIds: reservation.layout.landIds,
+                });
+            } else {
+                log('种植', `背包种子 ${seed.name} ${reason}，已跳过`, {
+                    module: 'farm', event: '种植种子', result: 'skip_no_layout', strategy: 'bag_priority',
+                    seedId: seed.seedId, plantSize, emptyCount: remainingLandIds.length,
+                    landTypes: seed.landTypes || null, allowedCount: allowedLandIds.length,
+                });
+            }
             continue;
         }
 
@@ -401,6 +436,7 @@ async function plantFromBagSeeds(landsToPlant: any[], landTypeById?: Map<number,
         plantedLandIds: [...new Set(plantedLandIds)],
         totalPlanted,
         occupiedCount: occupiedIds.size,
+        deferredLandIds: [...deferredLandIds],
     };
 }
 
@@ -624,10 +660,13 @@ async function resolveLandTypeMapForBagSeeds(knownLands: any[]): Promise<Map<num
     return landTypeById;
 }
 
-async function autoPlantEmptyLands(deadLandIds: number[], emptyLandIds: number[], options: { propagateErrors?: boolean } = {}): Promise<any> {
+async function autoPlantEmptyLands(deadLandIds: number[], emptyLandIds: number[], options: {
+    propagateErrors?: boolean;
+    knownLands?: any[];
+} = {}): Promise<any> {
     let landsToPlant: number[] = [...new Set<number>((Array.isArray(emptyLandIds) ? emptyLandIds : [])
         .map((id: any) => toNum(id)).filter((id: number) => id > 0))];
-    let latestLands: any[] = [];
+    let latestLands: any[] = Array.isArray(options.knownLands) ? options.knownLands : [];
     const state = getUserState();
 
     // 1. 铲除枯死/收获残留植物（一键操作），随后以服务端最新状态确认可用土地。
@@ -664,7 +703,14 @@ async function autoPlantEmptyLands(deadLandIds: number[], emptyLandIds: number[]
         let bagResult: any;
         try {
             const landTypeById = await resolveLandTypeMapForBagSeeds(latestLands);
-            bagResult = await plantFromBagSeeds(landsToPlant, landTypeById, options);
+            const allUnlockedLandIds = latestLands
+                .filter((land: any) => !!(land && land.unlocked))
+                .map((land: any) => toNum(land.id))
+                .filter((id: number) => id > 0);
+            bagResult = await plantFromBagSeeds(landsToPlant, landTypeById, {
+                propagateErrors: options.propagateErrors,
+                allUnlockedLandIds,
+            });
         } catch (e: any) {
             logWarn('种植', `读取背包种子失败，本轮跳过第二优先策略以避免误购: ${e.message}`, {
                 module: 'farm',
@@ -695,7 +741,10 @@ async function autoPlantEmptyLands(deadLandIds: number[], emptyLandIds: number[]
         if (plantedLands.length > 0) {
             await runFertilizerByConfig(plantedLands, options);
         }
-        return { plantedLands: [...new Set(plantedLands)] };
+        return {
+            plantedLands: [...new Set(plantedLands)],
+            deferredLandIds: bagResult.deferredLandIds || [],
+        };
     }
 
     // 其他策略：从商店购买种植

--- a/core/src/services/farm/planting.ts
+++ b/core/src/services/farm/planting.ts
@@ -5,7 +5,7 @@ export {};
 
 const protobuf = require('protobufjs');
 const { getPlantNameBySeedId, formatGrowTime, getPlantGrowTime, getAllSeeds, getPlantBySeedId } = require('../../config/gameConfig');
-const { getPreferredSeed, getAutomation, getPlantingStrategy, getBagSeedPriority, getBagSeedLandTypes, getBagSeedFallbackStrategy } = require('../../models/store');
+const { getPreferredSeed, getAutomation, getPlantingStrategy, getBagSeedPriority, getBagSeedMultiLandReservationEnabled, getBagSeedLandTypes, getBagSeedFallbackStrategy } = require('../../models/store');
 const { getUserState, getWsErrorState, sendMsgAsync } = require('../../utils/network');
 const { toNum, getServerTimeSec, log, logWarn, sleep } = require('../../utils/utils');
 const { types } = require('../../utils/proto');
@@ -247,6 +247,7 @@ async function plantFromBagSeeds(landsToPlant: any[], landTypeById?: Map<number,
     const bagSeeds = await getBagSeeds();
     const state = getUserState();
     const priorityList = getBagSeedPriority();
+    const multiLandReservationEnabled = getBagSeedMultiLandReservationEnabled();
     const explicitPrioritySeedIds = new Set<number>((Array.isArray(priorityList) ? priorityList : [])
         .map((seedId: any) => toNum(seedId))
         .filter((seedId: number) => seedId > 0));
@@ -362,7 +363,8 @@ async function plantFromBagSeeds(landsToPlant: any[], landTypeById?: Map<number,
             const allEligibleLandIds = seed.landTypes
                 ? filterLandIdsByTypes(allUnlockedLandIds, landTypeById, seed.landTypes)
                 : allUnlockedLandIds;
-            const reservation = !futureLayoutReserved
+            const reservation = multiLandReservationEnabled
+                && !futureLayoutReserved
                 && plantSize > 1
                 && explicitPrioritySeedIds.has(toNum(seed.seedId))
                 ? selectFutureLayoutReservation(allowedLandIds, allEligibleLandIds, plantSize)

--- a/core/src/services/farm/scheduler.ts
+++ b/core/src/services/farm/scheduler.ts
@@ -244,10 +244,14 @@ async function runFarmOperation(
         // 注意：如果是单纯点"一键种植"，harvestedLandIds 为空，只种当前的空地/死地
         if (allDeadLands.length > 0 || allEmptyLands.length > 0) {
             try {
-                const plantCount = allDeadLands.length + allEmptyLands.length;
-                await autoPlantEmptyLands(allDeadLands, allEmptyLands, { propagateErrors });
-                actions.push(`种植${plantCount}`);
-                recordOperation('plant', plantCount);
+                const plantResult = await autoPlantEmptyLands(allDeadLands, allEmptyLands, { propagateErrors, knownLands: lands });
+                const plantedCount = Array.isArray(plantResult?.plantedLands) ? plantResult.plantedLands.length : 0;
+                const deferredCount = Array.isArray(plantResult?.deferredLandIds) ? plantResult.deferredLandIds.length : 0;
+                if (plantedCount > 0) {
+                    actions.push(`种植${plantedCount}`);
+                    recordOperation('plant', plantedCount);
+                }
+                if (deferredCount > 0) actions.push(`预留${deferredCount}`);
             } catch (e: any) {
                 logWarn('种植', e.message);
                 if (propagateErrors) throw e;

--- a/core/src/types/config.ts
+++ b/core/src/types/config.ts
@@ -85,6 +85,8 @@ export interface AccountConfig {
   fertilizerBuyNormalThresholdHours: number;
   fertilizerBuyCheckIntervalMinutes: number;
   bagSeedPriority: number[];
+  /** 是否为明确排在前面的多格背包种子保留尚未连成布局的空地。 */
+  bagSeedMultiLandReservationEnabled: boolean;
   /** seedId -> 允许种植的土地类型。缺 key 视为不限制。 */
   bagSeedLandTypes: Record<string, FertilizerLandType[]>;
   bagSeedFallbackStrategy: BagSeedFallbackStrategy;

--- a/core/tests/farm-multiland-reservation.test.js
+++ b/core/tests/farm-multiland-reservation.test.js
@@ -1,0 +1,60 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const {
+    selectFutureLayoutReservation,
+} = require('../dist/services/farm/layout-reservation');
+
+test('reserves the earliest stable 2x2 layout for a priority seed', () => {
+    const reservation = selectFutureLayoutReservation(
+        [1, 2, 3],
+        Array.from({ length: 15 }, (_, index) => index + 1),
+        2,
+    );
+
+    assert.deepEqual(reservation, {
+        layout: { anchorLandId: 5, landIds: [5, 6, 1, 2] },
+        reservedLandIds: [1, 2],
+    });
+});
+
+test('keeps accumulating empty lands in the selected future layout', () => {
+    const reservation = selectFutureLayoutReservation(
+        [1, 2, 5],
+        Array.from({ length: 15 }, (_, index) => index + 1),
+        2,
+    );
+
+    assert.deepEqual(reservation, {
+        layout: { anchorLandId: 5, landIds: [5, 6, 1, 2] },
+        reservedLandIds: [5, 1, 2],
+    });
+});
+
+test('prefers the earliest partial layout over a fuller later layout to avoid oscillation', () => {
+    const reservation = selectFutureLayoutReservation(
+        [1, 3, 4, 7],
+        Array.from({ length: 15 }, (_, index) => index + 1),
+        2,
+    );
+
+    assert.deepEqual(reservation, {
+        layout: { anchorLandId: 5, landIds: [5, 6, 1, 2] },
+        reservedLandIds: [1],
+    });
+});
+
+test('does not reserve when the multi-land layout is already plantable', () => {
+    const reservation = selectFutureLayoutReservation(
+        [1, 2, 5, 6],
+        Array.from({ length: 15 }, (_, index) => index + 1),
+        2,
+    );
+
+    assert.equal(reservation, null);
+});
+
+test('does not reserve single-land crops or impossible future layouts', () => {
+    assert.equal(selectFutureLayoutReservation([1], [1, 2, 5, 6], 1), null);
+    assert.equal(selectFutureLayoutReservation([1, 2, 3], [1, 2, 3, 4], 2), null);
+});

--- a/core/tests/farm-multiland-reservation.test.js
+++ b/core/tests/farm-multiland-reservation.test.js
@@ -4,6 +4,39 @@ const test = require('node:test');
 const {
     selectFutureLayoutReservation,
 } = require('../dist/services/farm/layout-reservation');
+const {
+    DEFAULT_ACCOUNT_CONFIG,
+    globalConfig,
+    normalizeAccountConfig,
+} = require('../dist/models/store/shared-state');
+const {
+    applyConfigSnapshot,
+} = require('../dist/models/store/account-config');
+
+test('keeps multi-land reservation opt-in by default', () => {
+    assert.equal(DEFAULT_ACCOUNT_CONFIG.bagSeedMultiLandReservationEnabled, false);
+    assert.equal(normalizeAccountConfig({}).bagSeedMultiLandReservationEnabled, false);
+    assert.equal(normalizeAccountConfig({ bagSeedMultiLandReservationEnabled: true }).bagSeedMultiLandReservationEnabled, true);
+});
+
+test('round-trips the multi-land reservation account setting', () => {
+    const accountId = '__multiland_reservation_test__';
+    try {
+        const enabled = applyConfigSnapshot(
+            { bagSeedMultiLandReservationEnabled: true },
+            { accountId, persist: false },
+        );
+        assert.equal(enabled.bagSeedMultiLandReservationEnabled, true);
+
+        const disabled = applyConfigSnapshot(
+            { bagSeedMultiLandReservationEnabled: false },
+            { accountId, persist: false },
+        );
+        assert.equal(disabled.bagSeedMultiLandReservationEnabled, false);
+    } finally {
+        delete globalConfig.accountConfigs[accountId];
+    }
+});
 
 test('reserves the earliest stable 2x2 layout for a priority seed', () => {
     const reservation = selectFutureLayoutReservation(

--- a/web/src/stores/setting.ts
+++ b/web/src/stores/setting.ts
@@ -71,6 +71,7 @@ export interface SettingsState {
   plantingStrategy: string
   preferredSeedId: number
   bagSeedPriority: number[]
+  bagSeedMultiLandReservationEnabled: boolean
   bagSeedLandTypes: Record<string, string[]>
   bagSeedFallbackStrategy: string
   intervals: IntervalsConfig
@@ -97,6 +98,7 @@ type SaveableSettingsKey
   = | 'plantingStrategy'
     | 'preferredSeedId'
     | 'bagSeedPriority'
+    | 'bagSeedMultiLandReservationEnabled'
     | 'bagSeedLandTypes'
     | 'bagSeedFallbackStrategy'
     | 'intervals'
@@ -122,6 +124,7 @@ const SAVEABLE_SETTINGS_KEYS: SaveableSettingsKey[] = [
   'plantingStrategy',
   'preferredSeedId',
   'bagSeedPriority',
+  'bagSeedMultiLandReservationEnabled',
   'bagSeedLandTypes',
   'bagSeedFallbackStrategy',
   'intervals',
@@ -147,6 +150,7 @@ function createDefaultSettings(): SettingsState {
     plantingStrategy: 'max_exp',
     preferredSeedId: 0,
     bagSeedPriority: [],
+    bagSeedMultiLandReservationEnabled: false,
     bagSeedLandTypes: {},
     bagSeedFallbackStrategy: 'level',
     intervals: {},
@@ -208,6 +212,7 @@ export const useSettingStore = defineStore('setting', () => {
       plantingStrategy: data.strategy || defaults.plantingStrategy,
       preferredSeedId: data.preferredSeed || defaults.preferredSeedId,
       bagSeedPriority: cloneValue(data.bagSeedPriority ?? defaults.bagSeedPriority),
+      bagSeedMultiLandReservationEnabled: data.bagSeedMultiLandReservationEnabled ?? defaults.bagSeedMultiLandReservationEnabled,
       bagSeedLandTypes: cloneValue(data.bagSeedLandTypes ?? defaults.bagSeedLandTypes),
       bagSeedFallbackStrategy: data.bagSeedFallbackStrategy ?? defaults.bagSeedFallbackStrategy,
       intervals: cloneValue(data.intervals || defaults.intervals),

--- a/web/src/views/Settings.vue
+++ b/web/src/views/Settings.vue
@@ -251,6 +251,7 @@ const localStrategySettings = ref({
   plantingStrategy: 'max_exp',
   preferredSeedId: 0,
   bagSeedPriority: [] as number[],
+  bagSeedMultiLandReservationEnabled: false,
   bagSeedLandTypes: {} as Record<string, string[]>,
   bagSeedFallbackStrategy: 'level',
   stealDelaySeconds: 0,
@@ -718,6 +719,7 @@ function syncLocalStrategySettings() {
       plantingStrategy: settings.value.plantingStrategy,
       preferredSeedId: settings.value.preferredSeedId,
       bagSeedPriority: settings.value.bagSeedPriority ?? [],
+      bagSeedMultiLandReservationEnabled: !!settings.value.bagSeedMultiLandReservationEnabled,
       bagSeedLandTypes: settings.value.bagSeedLandTypes ?? {},
       bagSeedFallbackStrategy: settings.value.bagSeedFallbackStrategy ?? 'level',
       stealDelaySeconds: settings.value.stealDelaySeconds ?? 0,
@@ -1695,6 +1697,15 @@ async function handleResetSystemConfig() {
                 :options="BAG_FALLBACK_STRATEGY_OPTIONS"
                 @change="handleBagFallbackStrategyChange"
               />
+              <div class="border border-gray-200 rounded-lg bg-gray-50/70 p-3 dark:border-gray-700 dark:bg-gray-800/40">
+                <BaseSwitch
+                  v-model="localStrategySettings.bagSeedMultiLandReservationEnabled"
+                  label="为高优先级多格种子预留土地"
+                />
+                <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                  开启后可能暂时留空部分土地，直到明确排在前面的多格种子凑齐连续布局。默认关闭。
+                </p>
+              </div>
               <div class="border border-amber-200 rounded-lg bg-amber-50/70 p-3 space-y-3 dark:border-amber-800/50 dark:bg-amber-900/20">
                 <div class="flex flex-wrap items-start justify-between gap-3">
                   <div>


### PR DESCRIPTION
## 问题

背包优先策略遇到高优先级 2×2 种子时，如果本轮空地暂时凑不出连续布局，会继续用低优先级 1×1 种子填满空地，导致多格种子可能长期无法种下。

## 修复

- 新增账号级“为高优先级多格种子预留土地”开关，默认关闭
- 仅在用户主动开启后，为显式优先列表中的多格种子预留土地
- 从已解锁且符合土地类型限制的地块中选择稳定的未来布局
- 每轮只预留一组布局，其他空地仍可使用后续种子或回退策略
- 使用最早合法锚点避免候选布局在轮次间来回漂移
- 设置页明确提示开启后可能产生土地空档期
- 农场循环区分实际种植数量与预留土地数量

## 验证

- 多格布局及配置开关专项测试 7 项通过
- `pnpm -C core test`：148 项全部通过
- `pnpm -C web build`：通过
- `pnpm -C web typecheck`：通过
- 本次新增代码的定向 ESLint 检查通过（排除文件中已有的基线规则问题）